### PR TITLE
Swapped conversion functions to correct versions

### DIFF
--- a/Curve25519Dalek/Defs.lean
+++ b/Curve25519Dalek/Defs.lean
@@ -34,7 +34,13 @@ def h : Nat := 8
 def U64x5_as_Nat (limbs : Array U64 5#usize) : Nat :=
   ∑ i ∈ Finset.range 5, 2^(51 * i) * (limbs[i]!).val
 
-/-- Auxiliary definition to interpret a Scalar52 (5 u64 limbs with 52-bit representation) as a natural number -/
+/-- Auxiliary definition to interpret a Field51 (five u64 limbs used to represent 51 bits each) as a natural number -/
+@[simp]
+def Field51_as_Nat (limbs : Array U64 5#usize) : Nat :=
+  ∑ i ∈ Finset.range 5, 2^(51 * i) * (limbs[i]!).val
+
+/-- Auxiliary definition to interpret a Scalar52 (five u64 limbs used to represent 52 bits each) as a natural number -/
+@[simp]
 def Scalar52_as_Nat (limbs : Array U64 5#usize) : Nat :=
   ∑ i ∈ Finset.range 5, 2^(52 * i) * (limbs[i]!).val
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/FromBytes.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/FromBytes.lean
@@ -222,7 +222,7 @@ Specification:
 @[progress]
 theorem from_bytes_spec (bytes : Array U8 32#usize) :
     ∃ result, from_bytes bytes = ok result ∧
-    U64x5_as_Nat result ≡ (U8x32_as_Nat bytes % 2^255) [MOD p] := by
+    Field51_as_Nat result ≡ (U8x32_as_Nat bytes % 2^255) [MOD p] := by
   sorry
 
 end curve25519_dalek.backend.serial.u64.field.FieldElement51

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/Pow2K.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/Pow2K.lean
@@ -31,7 +31,7 @@ natural language description:
 natural language specs:
 
     • The function always succeeds (no panic)
-    • U64x5_as_Nat(result) ≡ U64x5_as_Nat(a)^(2^k) (mod p)
+    • Field51_as_Nat(result) ≡ Field51_as_Nat(a)^(2^k) (mod p)
 -/
 
 /-- **Spec and proof concerning `backend.serial.u64.field.FieldElement51.pow2k`**:
@@ -41,7 +41,7 @@ natural language specs:
 -/
 theorem pow2k_spec (a : Array U64 5#usize) (k : U32) :
     ∃ r, pow2k a k = ok r ∧
-    U64x5_as_Nat r ≡ (U64x5_as_Nat a)^(2^k.val) [MOD p]
+    Field51_as_Nat r ≡ (Field51_as_Nat a)^(2^k.val) [MOD p]
     := by
   sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/Square2.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/Square2.lean
@@ -30,7 +30,7 @@ natural language description:
 natural language specs:
 
     • The function always succeeds (no panic)
-    • U64x5_as_Nat(result) ≡ 2 * U64x5_as_Nat(a)² (mod p)
+    • Field51_as_Nat(result) ≡ 2 * Field51_as_Nat(a)² (mod p)
 -/
 
 /-- **Spec and proof concerning `backend.serial.u64.field.FieldElement51.square2`**:
@@ -40,7 +40,7 @@ natural language specs:
 theorem square2_spec (a : Array U64 5#usize) :
     ∃ r,
     square2 a = ok r ∧
-    U64x5_as_Nat r % p = (2 * (U64x5_as_Nat a)^2) % p
+    Field51_as_Nat r % p = (2 * (Field51_as_Nat a)^2) % p
     := by
   sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/Sub.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/Sub.lean
@@ -34,20 +34,20 @@ natural language description:
 natural language specs:
 
     • For all FieldElement51s a and b:
-      U64x5_as_Nat(sub(a, b)) ≡ U64x5_as_Nat(a) - U64x5_as_Nat(b) (mod p)
+      Field51_as_Nat(sub(a, b)) ≡ Field51_as_Nat(a) - Field51_as_Nat(b) (mod p)
       where p = 2^255 - 19
 -/
 
 /-- **Spec and proof concerning `backend.serial.u64.field.FieldElement51.sub`**:
 - No panic (always succeeds due to bias addition preventing underflow)
 - The result c satisfies the field subtraction property:
-  U64x5_as_Nat(c) ≡ U64x5_as_Nat(a) - U64x5_as_Nat(b) (mod p)
+  Field51_as_Nat(c) ≡ Field51_as_Nat(a) - Field51_as_Nat(b) (mod p)
   where p = 2^255 - 19
 -/
 theorem sub_spec (a b : Array U64 5#usize) :
     ∃ c,
     sub a b = ok c ∧
-    U64x5_as_Nat c % p = (U64x5_as_Nat a - U64x5_as_Nat b) % p
+    Field51_as_Nat c % p = (Field51_as_Nat a - Field51_as_Nat b) % p
     := by
   sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/SubAssign.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/SubAssign.lean
@@ -34,20 +34,20 @@ natural language description:
 natural language specs:
 
     • For all FieldElement51s a and b:
-      U64x5_as_Nat(sub_assign(a, b)) ≡ U64x5_as_Nat(a) - U64x5_as_Nat(b) (mod p)
+      Field51_as_Nat(sub_assign(a, b)) ≡ Field51_as_Nat(a) - Field51_as_Nat(b) (mod p)
       where p = 2^255 - 19
 -/
 
 /-- **Spec and proof concerning `backend.serial.u64.field.FieldElement51.sub_assign`**:
 - No panic (always succeeds since it delegates to `sub`)
 - The result c satisfies the field subtraction property:
-  U64x5_as_Nat(c) ≡ U64x5_as_Nat(a) - U64x5_as_Nat(b) (mod p)
+  Field51_as_Nat(c) ≡ Field51_as_Nat(a) - Field51_as_Nat(b) (mod p)
   where p = 2^255 - 19
 -/
 theorem sub_assign_spec (a b : Array U64 5#usize) :
     ∃ c,
     sub_assign a b = ok c ∧
-    U64x5_as_Nat c % p = (U64x5_as_Nat a - U64x5_as_Nat b) % p
+    Field51_as_Nat c % p = (Field51_as_Nat a - Field51_as_Nat b) % p
     := by
   sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/Add.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/Add.lean
@@ -39,7 +39,7 @@ natural language specs:
 theorem add_spec (u u' : Scalar52) :
     ∃ v,
     add u u' = ok v ∧
-    U64x5_as_Nat v = (U64x5_as_Nat u + U64x5_as_Nat u') % L
+    Scalar52_as_Nat v = (Scalar52_as_Nat u + Scalar52_as_Nat u') % L
     := by
   sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/ConditionalAddL.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/ConditionalAddL.lean
@@ -45,8 +45,8 @@ natural language specs:
 theorem conditional_add_l_spec (u : Scalar52) (c : subtle.Choice) :
     ∃ carry u',
     conditional_add_l u c = ok (carry, u') ∧
-    (c.val = 1#u8 → U64x5_as_Nat u' + carry.val * 2^260 = U64x5_as_Nat u + L) ∧
-    (c.val = 0#u8 → U64x5_as_Nat u' = U64x5_as_Nat u ∧ carry.val = 0)
+    (c.val = 1#u8 → Scalar52_as_Nat u' + carry.val * 2^260 = Scalar52_as_Nat u + L) ∧
+    (c.val = 0#u8 → Scalar52_as_Nat u' = Scalar52_as_Nat u ∧ carry.val = 0)
     := by
   sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/FromBytes.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/FromBytes.lean
@@ -39,7 +39,7 @@ natural language specs:
 theorem from_bytes_spec (b : Array U8 32#usize) :
     ∃ u,
     from_bytes b = ok u ∧
-    U64x5_as_Nat u = U8x32_as_Nat b
+    Scalar52_as_Nat u = U8x32_as_Nat b
     := by
     sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/FromBytesWide.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/FromBytesWide.lean
@@ -39,7 +39,7 @@ natural language specs:
 theorem from_bytes_wide_spec (b : Array U8 64#usize) :
     ∃ u,
     from_bytes_wide b = ok u ∧
-    U64x5_as_Nat u = U8x64_as_Nat b % L
+    Scalar52_as_Nat u = U8x64_as_Nat b % L
     := by
     sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/FromMontgomery.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/FromMontgomery.lean
@@ -40,7 +40,7 @@ natural language specs:
 theorem from_montgomery_spec (m : Scalar52) :
     ∃ u,
     from_montgomery m = ok u ∧
-    (U64x5_as_Nat u * R) % L = U64x5_as_Nat m % L
+    (Scalar52_as_Nat u * R) % L = Scalar52_as_Nat m % L
     := by
   sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/Invert.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/Invert.lean
@@ -24,10 +24,10 @@ namespace curve25519_dalek.scalar.Scalar52
 /-
 natural language description:
 
-    • Takes as input an UnpackedScalar r and returns another UnpackedScalar r’ that
-      represents the multiplicative inverse of r within the underlying
+    • Takes as input an UnpackedScalar u and returns another UnpackedScalar u’ that
+      represents the multiplicative inverse of u within the underlying
       field \mathbb{Z} / \ell \mathbb{Z}. This is done by first
-      converting r into Montgomery form, then inverting with
+      converting u into Montgomery form, then inverting with
       montgomery_invert, and then converting back into UnpackedScalar.
 
 natural language specs:
@@ -40,12 +40,12 @@ natural language specs:
 - Precondition: The unpacked input scalar u must be non-zero (inverting zero has undefined behavior)
 - No panic (returns successfully for non-zero input)
 - The result u' satisfies the multiplicative inverse property:
-  U64x5_as_Nat(u) * U64x5_as_Nat(u') ≡ 1 (mod L)
+  Scalar52_as_Nat(u) * Scalar52_as_Nat(u') ≡ 1 (mod L)
 -/
 theorem invert_spec (u : Scalar52) (h : u ≠ ZERO) :
     ∃ u',
     invert u = ok u' ∧
-    (U64x5_as_Nat u * U64x5_as_Nat u') ≡ 1 [MOD L]
+    (Scalar52_as_Nat u * Scalar52_as_Nat u') ≡ 1 [MOD L]
     := by
   sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/MontgomeryInvert.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/MontgomeryInvert.lean
@@ -36,7 +36,7 @@ natural language specs:
 
     • For any non-zero UnpackedScalar u in Montgomery form:
       - The function returns successfully with result u'
-      - (U64x5_as_Nat u * U64x5_as_Nat u') mod L = R² mod L
+      - (Scalar52_as_Nat u * Scalar52_as_Nat u') mod L = R² mod L
       - This is equivalent to: montgomery_mul(u, u') = R mod L
 -/
 
@@ -48,7 +48,7 @@ natural language specs:
 theorem montgomery_invert_spec (u : Scalar52) (h : u ≠ ZERO) :
     ∃ u',
     montgomery_invert u = ok u' ∧
-    (U64x5_as_Nat u * U64x5_as_Nat u') % L = (R * R) % L
+    (Scalar52_as_Nat u * Scalar52_as_Nat u') % L = (R * R) % L
     := by
   sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/MontgomeryReduce.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/MontgomeryReduce.lean
@@ -37,7 +37,7 @@ natural language specs:
 
     • For any 9-limb array a of u128 values:
       - The function returns a Scalar52 m such that:
-        U64x5_as_Nat(m) * R ≡ U128x9_as_Nat(a) (mod L)
+        Scalar52_as_Nat(m) * R ≡ U128x9_as_Nat(a) (mod L)
 -/
 
 /-- **Spec and proof concerning `scalar.Scalar52.montgomery_reduce`**:
@@ -48,7 +48,7 @@ natural language specs:
 theorem montgomery_reduce_spec (a : Array U128 9#usize) :
     ∃ m,
     montgomery_reduce a = ok m ∧
-    (U64x5_as_Nat m * R) % L = U128x9_as_Nat a % L
+    (Scalar52_as_Nat m * R) % L = U128x9_as_Nat a % L
     := by
   sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/MontgomerySquare.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/MontgomerySquare.lean
@@ -32,7 +32,7 @@ natural language description:
 natural language specs:
 
     • For any UnpackedScalar m in Montgomery form:
-      - (U64x5_as_Nat m * U64x5_as_Nat m) mod L = (U64x5_as_Nat w * R) mod L
+      - (Scalar52_as_Nat m * Scalar52_as_Nat m) mod L = (Scalar52_as_Nat w * R) mod L
 -/
 
 /-- **Spec and proof concerning `scalar.Scalar52.montgomery_square`**:
@@ -43,7 +43,7 @@ natural language specs:
 theorem montgomery_square_spec (m : Scalar52) :
     ∃ w,
     montgomery_square m = ok w ∧
-    (U64x5_as_Nat m * U64x5_as_Nat m) % L = (U64x5_as_Nat w * R) % L
+    (Scalar52_as_Nat m * Scalar52_as_Nat m) % L = (Scalar52_as_Nat w * R) % L
     := by
   sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/Pack.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/Pack.lean
@@ -42,7 +42,7 @@ theorem pack_spec (u : Scalar52) :
     ∃ s,
     pack u = ok s ∧
     unpack s = ok u ∧
-    U8x32_as_Nat s.bytes = U64x5_as_Nat u
+    U8x32_as_Nat s.bytes = Scalar52_as_Nat u
     := by
   sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/Sub.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/Sub.lean
@@ -71,7 +71,7 @@ theorem sub_spec (a b : Array U64 5#usize)
     (ha : ∀ i, i < 5 → (a[i]!).val < 2 ^ 52)
     (hb : ∀ i, i < 5 → (b[i]!).val < 2 ^ 52) :
     ∃ result, sub a b = ok result ∧
-    U64x5_as_Nat result ≡ (U64x5_as_Nat a - U64x5_as_Nat b) [MOD L] := by
+    Scalar52_as_Nat result ≡ (Scalar52_as_Nat a - Scalar52_as_Nat b) [MOD L] := by
   unfold sub
   -- progress*
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/ToBytes.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/ToBytes.lean
@@ -40,7 +40,7 @@ natural language specs:
 theorem to_bytes_spec (u : Scalar52) :
     ∃ b,
     to_bytes u = ok b ∧
-    U8x32_as_Nat b ≡ U64x5_as_Nat u [MOD L]
+    U8x32_as_Nat b ≡ Scalar52_as_Nat u [MOD L]
     := by
     sorry
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/Zero.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/Zero.lean
@@ -25,7 +25,7 @@ namespace curve25519_dalek.backend.serial.u64.scalar.Scalar52
 The ZERO constant represents the scalar 0.
 -/
 @[simp]
-theorem ZERO_spec : U64x5_as_Nat ZERO = 0 := by
+theorem ZERO_spec : Scalar52_as_Nat ZERO = 0 := by
   unfold ZERO ZERO_body
   decide
 

--- a/Curve25519Dalek/Specs/Scalar/Scalar/Unpack.lean
+++ b/Curve25519Dalek/Specs/Scalar/Scalar/Unpack.lean
@@ -42,7 +42,7 @@ theorem unpack_spec (s : Scalar) :
     ∃ u,
     unpack s = ok u ∧
     pack u = ok s ∧
-    U64x5_as_Nat u = U8x32_as_Nat s.bytes
+    Scalar52_as_Nat u = U8x32_as_Nat s.bytes
     := by
   sorry
 


### PR DESCRIPTION
Instead of U64x5_as_Nat we now consider two distinct conversion functions:

- Scalar52_as_Nat
- Field51_as_Nat

I have rewritten many specs using the correct version of the conversion function in each case, depending on whether we deal with Scalar52 or Field51 elements.

I have also made a hit list of seven functions which already have a proof but still need swapping of conversion functions. Directly swapping the conversion functions here may break the proof, so these seven functions need further more attention. Here is the hit list:


Field / FieldElement51 functions with completed proofs that need swapping of conversion function from U64x5_as_Nat to Field51_as_Nat:

- Add.lean
- AsBytes.lean
- Reduce.lean
- Square.lean
- ToBytes.lean


Scalar52 functions with completed proofs that need swapping of conversion function from U64x5_as_Nat to Scalar52_as_Nat:

- SquareInternal.lean
- MulInternal.lean


