### PR TITLE
Added two more formal Lean specs and proofs

### DIFF
--- a/Curve25519Dalek/Specs/Ristretto/CompressedRistretto/AsBytes.lean
+++ b/Curve25519Dalek/Specs/Ristretto/CompressedRistretto/AsBytes.lean
@@ -1,20 +1,47 @@
+/-
+Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Dablander
+-/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Defs
 
-/-! # as_bytes
+/-! # Spec Theorem for `CompressedRistretto::as_bytes`
 
 Specification and proof for `CompressedRistretto::as_bytes`.
 
 This function converts the structure to its byte representation.
 
-**Source**: curve25519-dalek/src/ristretto.rs:L233-L236
-
-## TODO
-- Write draft specification
-- Write formal specification
-- Complete proof
+**Source**: curve25519-dalek/src/ristretto.rs
 -/
 
-open Aeneas.Std Result curve25519_dalek
+open Aeneas.Std Result
+namespace curve25519_dalek.ristretto.CompressedRistretto
 
--- Specification theorem to be written here
+/-
+natural language description:
+
+    • Extract the byte representation of type [u8;32] from a CompressedRistretto cr.
+      Since CompressedRistretto is defined as a type alias for Array U8 32#usize,
+      this is essentially an identity operation that returns the underlying byte array.
+
+natural language specs:
+
+    • as_bytes(cr) = cr, i.e., the function is the identity operation
+    • The operation never panics (always returns successfully)
+-/
+
+/-- **Spec and proof concerning `ristretto.CompressedRistretto.as_bytes`**:
+- No panic (always returns successfully)
+- The result is the byte representation of the compressed Ristretto point
+- Since CompressedRistretto is defined as Array U8 32#usize, as_bytes is essentially the identity
+-/
+theorem as_bytes_spec (cr : CompressedRistretto) :
+    ∃ b,
+    as_bytes cr = ok b ∧
+    b = cr
+    := by
+  unfold as_bytes
+  simp
+
+end curve25519_dalek.ristretto.CompressedRistretto

--- a/Curve25519Dalek/Specs/Ristretto/CompressedRistretto/ToBytes.lean
+++ b/Curve25519Dalek/Specs/Ristretto/CompressedRistretto/ToBytes.lean
@@ -1,20 +1,47 @@
+/-
+Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Dablander
+-/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Defs
 
-/-! # to_bytes
+/-! # Spec Theorem for `CompressedRistretto::to_bytes`
 
 Specification and proof for `CompressedRistretto::to_bytes`.
 
-This function converts the structure to a byte array.
+This function converts the structure to its byte representation.
 
-**Source**: curve25519-dalek/src/ristretto.rs:L228-L231
-
-## TODO
-- Write draft specification
-- Write formal specification
-- Complete proof
+**Source**: curve25519-dalek/src/ristretto.rs
 -/
 
-open Aeneas.Std Result curve25519_dalek
+open Aeneas.Std Result
+namespace curve25519_dalek.ristretto.CompressedRistretto
 
--- Specification theorem to be written here
+/-
+natural language description:
+
+    • Extract the byte representation of type [u8;32] from a CompressedRistretto cr.
+      Since CompressedRistretto is defined as a type alias for Array U8 32#usize,
+      this is essentially an identity operation that returns the underlying byte array.
+
+natural language specs:
+
+    • to_bytes(cr) = cr, i.e., the function is the identity operation
+    • The operation never panics (always returns successfully)
+-/
+
+/-- **Spec and proof concerning `ristretto.CompressedRistretto.to_bytes`**:
+- No panic (always returns successfully)
+- The result is the byte representation of the compressed Ristretto point
+- Since CompressedRistretto is defined as Array U8 32#usize, to_bytes is essentially the identity
+-/
+theorem to_bytes_spec (cr : CompressedRistretto) :
+    ∃ b,
+    to_bytes cr = ok b ∧
+    b = cr
+    := by
+  unfold to_bytes
+  simp
+
+end curve25519_dalek.ristretto.CompressedRistretto

--- a/status.csv
+++ b/status.csv
@@ -53,10 +53,10 @@ curve25519_dalek::edwards::EdwardsPoint::multiscalar_mul,curve25519-dalek/src/ed
 curve25519_dalek::edwards::EdwardsPoint::to_montgomery,curve25519-dalek/src/edwards.rs,L552-L559,,,,
 curve25519_dalek::edwards::EdwardsPoint::vartime_double_scalar_mul_basepoint,curve25519-dalek/src/edwards.rs,L901-L912,,,,
 curve25519_dalek::montgomery::MontgomeryPoint::to_edwards,curve25519-dalek/src/montgomery.rs,L216-L252,,,,
-curve25519_dalek::ristretto::CompressedRistretto::as_bytes,curve25519-dalek/src/ristretto.rs,L234-L236,,extracted,,
+curve25519_dalek::ristretto::CompressedRistretto::as_bytes,curve25519-dalek/src/ristretto.rs,L234-L236,,extracted,verified,Verified (markus-dablander)
 curve25519_dalek::ristretto::CompressedRistretto::decompress,curve25519-dalek/src/ristretto.rs,L255-L382,,,,
 curve25519_dalek::ristretto::CompressedRistretto::from_slice,curve25519-dalek/src/ristretto.rs,L244-L246,,,,
-curve25519_dalek::ristretto::CompressedRistretto::to_bytes,curve25519-dalek/src/ristretto.rs,L229-L231,,extracted,,
+curve25519_dalek::ristretto::CompressedRistretto::to_bytes,curve25519-dalek/src/ristretto.rs,L229-L231,,extracted,verified,Verified (markus-dablander)
 curve25519_dalek::ristretto::RistrettoPoint::compress,curve25519-dalek/src/ristretto.rs,L488-L522,,,,
 curve25519_dalek::ristretto::RistrettoPoint::default,curve25519-dalek/src/ristretto.rs,L813-L816,,,,
 curve25519_dalek::ristretto::RistrettoPoint::double_and_compress_batch,curve25519-dalek/src/ristretto.rs,L552-L636,,,,

--- a/status.md
+++ b/status.md
@@ -60,10 +60,10 @@ This document tracks the progress of formally verifying functions from the curve
 | `to_montgomery` | [edwards.rs](curve25519-dalek/src/edwards.rs#L552-L559) | - | ☐ | ☐ |  |
 | `vartime_double_scalar_mul_basepoint` | [edwards.rs](curve25519-dalek/src/edwards.rs#L901-L912) | - | ☐ | ☐ |  |
 | `to_edwards` | [montgomery.rs](curve25519-dalek/src/montgomery.rs#L216-L252) | - | ☐ | ☐ |  |
-| `as_bytes` | [ristretto.rs](curve25519-dalek/src/ristretto.rs#L234-L236) | - | ✅ | ☐ |  |
+| `as_bytes` | [ristretto.rs](curve25519-dalek/src/ristretto.rs#L234-L236) | - | ✅ | ✅ | Verified (markus-dablander) |
 | `decompress` | [ristretto.rs](curve25519-dalek/src/ristretto.rs#L255-L382) | - | ☐ | ☐ |  |
 | `from_slice` | [ristretto.rs](curve25519-dalek/src/ristretto.rs#L244-L246) | - | ☐ | ☐ |  |
-| `to_bytes` | [ristretto.rs](curve25519-dalek/src/ristretto.rs#L229-L231) | - | ✅ | ☐ |  |
+| `to_bytes` | [ristretto.rs](curve25519-dalek/src/ristretto.rs#L229-L231) | - | ✅ | ✅ | Verified (markus-dablander) |
 | `compress` | [ristretto.rs](curve25519-dalek/src/ristretto.rs#L488-L522) | - | ☐ | ☐ |  |
 | `default` | [ristretto.rs](curve25519-dalek/src/ristretto.rs#L813-L816) | - | ☐ | ☐ |  |
 | `double_and_compress_batch` | [ristretto.rs](curve25519-dalek/src/ristretto.rs#L552-L636) | - | ☐ | ☐ |  |


### PR DESCRIPTION
Added formal Lean specs and proofs for:

- CompressedRistretto/AsBytes.lean
- CompressedRistretto/ToBytes.lean

Note that both these functions seem to be identical in the sense that they both appear to perform the exact same operation in Lean. The original Rust functions probably differed in their use of ownership semantics (creating a copy of the underlying byte array vs. simply referencing it), but this difference may be irrelevant in Lean.