### PR TITLE
Added formal Lean specs and proofs for four constants.

### DIFF
--- a/Curve25519Dalek/Defs.lean
+++ b/Curve25519Dalek/Defs.lean
@@ -21,6 +21,9 @@ def R : Nat := 2^260
 /-- The cofactor of Curve25519 -/
 def h : Nat := 8
 
+/-- The constant d in the defining equation for the twisted Edwards curve: -x^2 + y^2 = 1 + dx^2y^2 -/
+def d : Nat := 37095705934669439343138083508754565189542113879843219016388785533085940283555
+
 /-! ## Auxiliary definitions for interpreting arrays as natural numbers -/
 
 /-- Interpret a Field51 (five u64 limbs used to represent 51 bits each) as a natural number -/

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Constants/EDWARDS_D.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Constants/EDWARDS_D.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Dablander
+-/
+import Curve25519Dalek.Funs
+import Curve25519Dalek.Defs
+
+/-! # Spec Theorem for `constants::EDWARDS_D`
+
+Specification and proof for the constant `EDWARDS_D`.
+
+This constant represents the twisted Edwards curve parameter d.
+
+Source: curve25519-dalek/src/backend/serial/u64/constants.rs -/
+
+open Aeneas.Std Result
+namespace curve25519_dalek.backend.serial.u64
+
+/-
+natural language description:
+
+    • constants.EDWARDS_D is a constant representing the Edwards curve parameter d
+      in the defining curve equation -x^2 + y^2 = 1 + dx^2y^2.
+    • The field element constants.EDWARDS_D is represented as five u64 limbs (51-bit limbs)
+
+natural language specs:
+
+    • Field51_as_Nat(constants.EDWARDS_D) = d where d is the mathematical representation
+      of the Edwards curve parameter as a natural number.
+-/
+
+/-- **Spec and proof concerning `backend.serial.u64.constants.EDWARDS_D`**:
+- The value of constants.EDWARDS_D when converted to a natural number equals d
+-/
+theorem EDWARDS_D_spec : Field51_as_Nat constants.EDWARDS_D = d := by
+  unfold constants.EDWARDS_D
+  decide
+
+end curve25519_dalek.backend.serial.u64

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Constants/EDWARDS_D2.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Constants/EDWARDS_D2.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Dablander
+-/
+import Curve25519Dalek.Funs
+import Curve25519Dalek.Defs
+
+/-! # Spec Theorem for `constants::EDWARDS_D2`
+
+Specification and proof for the constant `EDWARDS_D2`.
+
+This constant represents 2*d (mod p) whereby d is the twisted Edwards curve parameter.
+
+Source: curve25519-dalek/src/backend/serial/u64/constants.rs -/
+
+open Aeneas.Std Result
+namespace curve25519_dalek.backend.serial.u64
+
+/-
+natural language description:
+
+    • constants.EDWARDS_D2 is a constant representing 2*d (mod p) whereby d is the
+      key parameter in the defining curve equation -x^2 + y^2 = 1 + dx^2y^2.
+    • The field element constants.EDWARDS_D2 is represented as five u64 limbs (51-bit limbs)
+
+natural language specs:
+
+    • Field51_as_Nat(constants.EDWARDS_D2) = 2*d (mod p) where d is the mathematical representation
+      of the Edwards curve parameter as a natural number.
+-/
+
+/-- **Spec and proof concerning `backend.serial.u64.constants.EDWARDS_D2`**:
+- The value of constants.EDWARDS_D2 when converted to a natural number equals
+  the canonical (reduced) representation of 2*d (mod p) in [0, p-1].
+-/
+theorem EDWARDS_D2_spec : Field51_as_Nat constants.EDWARDS_D2 =  (2 * d) % p := by
+  unfold constants.EDWARDS_D2
+  decide
+
+end curve25519_dalek.backend.serial.u64

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Constants/EDWARDS_D_MINUS_ONE_SQUARED.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Constants/EDWARDS_D_MINUS_ONE_SQUARED.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Dablander
+-/
+import Curve25519Dalek.Funs
+import Curve25519Dalek.Defs
+
+/-! # Spec Theorem for `constants::EDWARDS_D_MINUS_ONE_SQUARED`
+
+Specification and proof for the constant `EDWARDS_D_MINUS_ONE_SQUARED`.
+
+This constant represents (d - 1)² (mod p) whereby d is the twisted Edwards curve parameter.
+
+Source: curve25519-dalek/src/backend/serial/u64/constants.rs -/
+
+open Aeneas.Std Result
+namespace curve25519_dalek.backend.serial.u64
+
+/-
+natural language description:
+
+    • constants.EDWARDS_D_MINUS_ONE_SQUARED is a constant representing (d - 1)² (mod p) whereby d is the
+      key parameter in the defining curve equation -x^2 + y^2 = 1 + dx^2y^2.
+    • The field element constants.EDWARDS_D_MINUS_ONE_SQUARED is represented as five u64 limbs (51-bit limbs)
+
+natural language specs:
+
+    • Field51_as_Nat(constants.EDWARDS_D_MINUS_ONE_SQUARED) = (d - 1)² (mod p) where d is the mathematical representation
+      of the Edwards curve parameter as a natural number.
+-/
+
+/-- **Spec and proof concerning `backend.serial.u64.constants.EDWARDS_D_MINUS_ONE_SQUARED`**:
+- The value of constants.EDWARDS_D_MINUS_ONE_SQUARED when converted to a natural number equals
+  the canonical (reduced) representation of (d - 1)² (mod p) in [0, p-1].
+-/
+theorem EDWARDS_D_MINUS_ONE_SQUARED_spec : Field51_as_Nat constants.EDWARDS_D_MINUS_ONE_SQUARED = (d - 1)^2 % p := by
+  unfold constants.EDWARDS_D_MINUS_ONE_SQUARED
+  decide
+
+end curve25519_dalek.backend.serial.u64

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Constants/ONE_MINUS_EDWARDS_D_SQUARED.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Constants/ONE_MINUS_EDWARDS_D_SQUARED.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Dablander
+-/
+import Curve25519Dalek.Funs
+import Curve25519Dalek.Defs
+
+/-! # Spec Theorem for `constants::ONE_MINUS_EDWARDS_D_SQUARED`
+
+Specification and proof for the constant `ONE_MINUS_EDWARDS_D_SQUARED`.
+
+This constant represents 1 - d² (mod p) whereby d is the twisted Edwards curve parameter.
+
+Source: curve25519-dalek/src/backend/serial/u64/constants.rs -/
+
+open Aeneas.Std Result
+namespace curve25519_dalek.backend.serial.u64
+
+/-
+natural language description:
+
+    • constants.ONE_MINUS_EDWARDS_D_SQUARED is a constant representing 1 - d² (mod p) whereby d is the
+      key parameter in the defining curve equation -x^2 + y^2 = 1 + dx^2y^2.
+    • The field element constants.ONE_MINUS_EDWARDS_D_SQUARED is represented as five u64 limbs (51-bit limbs)
+    • Note that the original Rust comment states
+      "One minus edwards `d` value squared, equal to `(1 - (-121665/121666) mod p) pow 2`",
+      however, there seems to be a typo/error in this comment, as it appears that the constant (as defined) is
+      congruent to 1 - d^2 and not to (1 - d)^2.
+
+natural language specs:
+
+    • Field51_as_Nat(constants.ONE_MINUS_EDWARDS_D_SQUARED) = (1 - d²) (mod p) where d is the mathematical representation
+      of the Edwards curve parameter as a natural number.
+-/
+
+/-- **Spec and proof concerning `backend.serial.u64.constants.ONE_MINUS_EDWARDS_D_SQUARED`**:
+- The value of constants.ONE_MINUS_EDWARDS_D_SQUARED when converted to a natural number equals
+  the canonical (reduced) representation of (1 - d²) (mod p) in [0, p-1].
+  Note: the extra " + p" in the spec theorem is to avoided hitting 0 in the truncated subtraction
+  implemented by Lean.
+-/
+theorem ONE_MINUS_EDWARDS_D_SQUARED_spec : Field51_as_Nat constants.ONE_MINUS_EDWARDS_D_SQUARED = (1 + p - (d^2 % p)) % p:= by
+  unfold constants.ONE_MINUS_EDWARDS_D_SQUARED
+  decide
+
+end curve25519_dalek.backend.serial.u64

--- a/status.csv
+++ b/status.csv
@@ -4,11 +4,11 @@ curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_projective,c
 curve25519_dalek::backend::serial::curve_models::ProjectivePoint::as_extended,curve25519-dalek/src/backend/serial/curve_models/mod.rs,L341-L348,Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/AsExtended.lean,extracted,,
 curve25519_dalek::backend::serial::curve_models::ProjectivePoint::double,curve25519-dalek/src/backend/serial/curve_models/mod.rs,L384-L419,Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/Double.lean,extracted,specified,
 curve25519_dalek::backend::serial::scalar_mul::vartime_double_base::mul,curve25519-dalek/src/backend/serial/scalar_mul/vartime_double_base.rs,L1-L15,Curve25519Dalek/Specs/Backend/Serial/ScalarMul/VartimeDoubleBase/Mul.lean,,,Extracts to broken Lean code
-curve25519_dalek::backend::serial::u64::constants::EDWARDS_D,curve25519-dalek/src/backend/serial/u64/constants.rs,L45-L51,,extracted,,
-curve25519_dalek::backend::serial::u64::constants::EDWARDS_D2,curve25519-dalek/src/backend/serial/u64/constants.rs,L54-L60,,extracted,,
+curve25519_dalek::backend::serial::u64::constants::EDWARDS_D,curve25519-dalek/src/backend/serial/u64/constants.rs,L45-L51,Curve25519Dalek/Specs/Backend/Serial/U64/Constants/EDWARDS_D.lean,extracted,verified,
+curve25519_dalek::backend::serial::u64::constants::EDWARDS_D2,curve25519-dalek/src/backend/serial/u64/constants.rs,L54-L60,Curve25519Dalek/Specs/Backend/Serial/U64/Constants/EDWARDS_D2.lean,extracted,verified,
 curve25519_dalek::backend::serial::u64::constants::INVSQRT_A_MINUS_D,curve25519-dalek/src/backend/serial/u64/constants.rs,L90-L96,,extracted,,
-curve25519_dalek::backend::serial::u64::constants::ONE_MINUS_EDWARDS_D_SQUARED,curve25519-dalek/src/backend/serial/u64/constants.rs,L63-L69,,extracted,,
-curve25519_dalek::backend::serial::u64::constants::EDWARDS_D_MINUS_ONE_SQUARED,curve25519-dalek/src/backend/serial/u64/constants.rs,L72-L78,,extracted,,
+curve25519_dalek::backend::serial::u64::constants::ONE_MINUS_EDWARDS_D_SQUARED,curve25519-dalek/src/backend/serial/u64/constants.rs,L63-L69,Curve25519Dalek/Specs/Backend/Serial/U64/Constants/ONE_MINUS_EDWARDS_D_SQUARED.lean,extracted,verified,
+curve25519_dalek::backend::serial::u64::constants::EDWARDS_D_MINUS_ONE_SQUARED,curve25519-dalek/src/backend/serial/u64/constants.rs,L72-L78,Curve25519Dalek/Specs/Backend/Serial/U64/Constants/EDWARDS_D_MINUS_ONE_SQUARED.lean,extracted,verified,
 curve25519_dalek::backend::serial::u64::constants::L,curve25519-dalek/src/backend/serial/u64/constants.rs,L127-L133,Curve25519Dalek/Specs/Backend/Serial/U64/Constants/L.lean,extracted,verified,Brackets required in extracted Lean
 curve25519_dalek::backend::serial::u64::constants::LFACTOR,curve25519-dalek/src/backend/serial/u64/constants.rs,L136-L136,Curve25519Dalek/Specs/Backend/Serial/U64/Constants/LFACTOR.lean,extracted,verified,
 curve25519_dalek::backend::serial::u64::constants::R,curve25519-dalek/src/backend/serial/u64/constants.rs,L139-L145,Curve25519Dalek/Specs/Backend/Serial/U64/Constants/R.lean,extracted,verified,

--- a/status.md
+++ b/status.md
@@ -11,11 +11,11 @@ This document tracks the progress of formally verifying functions from the curve
 | `as_extended` | [backend/serial/curve_models/mod.rs](curve25519-dalek/src/backend/serial/curve_models/mod.rs#L341-L348) | [AsExtended.lean](Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/AsExtended.lean) | ✅ | ☐ |  |
 | `double` | [backend/serial/curve_models/mod.rs](curve25519-dalek/src/backend/serial/curve_models/mod.rs#L384-L419) | [Double.lean](Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/Double.lean) | ✅ | 📋 |  |
 | `mul` | [backend/serial/scalar_mul/vartime_double_base.rs](curve25519-dalek/src/backend/serial/scalar_mul/vartime_double_base.rs#L1-L15) | [Mul.lean](Curve25519Dalek/Specs/Backend/Serial/ScalarMul/VartimeDoubleBase/Mul.lean) | ☐ | ☐ | Extracts to broken Lean code |
-| `EDWARDS_D` | [backend/serial/u64/constants.rs](curve25519-dalek/src/backend/serial/u64/constants.rs#L45-L51) | - | ✅ | ☐ |  |
-| `EDWARDS_D2` | [backend/serial/u64/constants.rs](curve25519-dalek/src/backend/serial/u64/constants.rs#L54-L60) | - | ✅ | ☐ |  |
+| `EDWARDS_D` | [backend/serial/u64/constants.rs](curve25519-dalek/src/backend/serial/u64/constants.rs#L45-L51) | [EDWARDS_D.lean](Curve25519Dalek/Specs/Backend/Serial/U64/Constants/EDWARDS_D.lean) | ✅ | ✅ |  |
+| `EDWARDS_D2` | [backend/serial/u64/constants.rs](curve25519-dalek/src/backend/serial/u64/constants.rs#L54-L60) | [EDWARDS_D2.lean](Curve25519Dalek/Specs/Backend/Serial/U64/Constants/EDWARDS_D2.lean) | ✅ | ✅ |  |
 | `INVSQRT_A_MINUS_D` | [backend/serial/u64/constants.rs](curve25519-dalek/src/backend/serial/u64/constants.rs#L90-L96) | - | ✅ | ☐ |  |
-| `ONE_MINUS_EDWARDS_D_SQUARED` | [backend/serial/u64/constants.rs](curve25519-dalek/src/backend/serial/u64/constants.rs#L63-L69) | - | ✅ | ☐ |  |
-| `EDWARDS_D_MINUS_ONE_SQUARED` | [backend/serial/u64/constants.rs](curve25519-dalek/src/backend/serial/u64/constants.rs#L72-L78) | - | ✅ | ☐ |  |
+| `ONE_MINUS_EDWARDS_D_SQUARED` | [backend/serial/u64/constants.rs](curve25519-dalek/src/backend/serial/u64/constants.rs#L63-L69) | [ONE_MINUS_EDWARDS_D_SQUARED.lean](Curve25519Dalek/Specs/Backend/Serial/U64/Constants/ONE_MINUS_EDWARDS_D_SQUARED.lean) | ✅ | ✅ |  |
+| `EDWARDS_D_MINUS_ONE_SQUARED` | [backend/serial/u64/constants.rs](curve25519-dalek/src/backend/serial/u64/constants.rs#L72-L78) | [EDWARDS_D_MINUS_ONE_SQUARED.lean](Curve25519Dalek/Specs/Backend/Serial/U64/Constants/EDWARDS_D_MINUS_ONE_SQUARED.lean) | ✅ | ✅ |  |
 | `L` | [backend/serial/u64/constants.rs](curve25519-dalek/src/backend/serial/u64/constants.rs#L127-L133) | [L.lean](Curve25519Dalek/Specs/Backend/Serial/U64/Constants/L.lean) | ✅ | ✅ | Brackets required in extracted Lean |
 | `LFACTOR` | [backend/serial/u64/constants.rs](curve25519-dalek/src/backend/serial/u64/constants.rs#L136-L136) | [LFACTOR.lean](Curve25519Dalek/Specs/Backend/Serial/U64/Constants/LFACTOR.lean) | ✅ | ✅ |  |
 | `R` | [backend/serial/u64/constants.rs](curve25519-dalek/src/backend/serial/u64/constants.rs#L139-L145) | [R.lean](Curve25519Dalek/Specs/Backend/Serial/U64/Constants/R.lean) | ✅ | ✅ |  |


### PR DESCRIPTION
Added an appropriate mathematical Lean constant $d$ to Defs.lean, which represents the numerical value of the key parameter in the defining equation of the twisted Edwards curve: 

$$ -x^2 + y^2 = 1 + dx^2y^2 . $$

Making use of the introduced Lean constant $d$, I formulated and proved formal Lean specs for:

- Constants/EDWARDS_D.lean,
- Constants/EDWARDS_D2.lean,
- Constants/EDWARDS_D_MINUS_ONE_SQUARED.lean,
- Constants/ONE_MINUS_EDWARDS_D_SQUARED.lean.

In the case of ONE_MINUS_EDWARDS_D_SQUARED.lean, I believe to have detected an error in the explanatory comment associated with this constant in the original Rust code, as the comment there appears to suggest that the constant is congruent to $(1 - d)^2$, when in reality I believe this should be $1 - d²$ instead. I am mentioning this potential Rust-documentation-error in a brief note in ONE_MINUS_EDWARDS_D_SQUARED.lean.
