### PR TITLE
Add missing file to imports

### DIFF
--- a/Curve25519Dalek.lean
+++ b/Curve25519Dalek.lean
@@ -15,6 +15,7 @@ import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Add
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.AddAssign
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.AsBytes
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.FromBytes
+import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Negate
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Pow2K
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Reduce
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Square


### PR DESCRIPTION
GPT-5-mini produced a proof for Negate, and `lake build` passed. Unfortunately it seems that `lake build` wasn't tracking that file, and the proof actually doesn't work :crying_cat_face: 

Is there a way to automatically import all files? IIRC in the vericoding lean repo, we didn't have one lean file that imported all other lean files