### PR TITLE
Removed unnecessary conversion function and corrected spec theorem for MontgomeryReduce

### DIFF
--- a/Curve25519Dalek/Defs.lean
+++ b/Curve25519Dalek/Defs.lean
@@ -41,10 +41,6 @@ def Scalar52_as_Nat (limbs : Array U64 5#usize) : Nat :=
 def Scalar52_wide_as_Nat (limbs : Array U128 9#usize) : Nat :=
   ∑ i ∈ Finset.range 9, 2^(52 * i) * (limbs[i]!).val
 
-/-- Interpret a 9-element u128 array (each limb representing 51 bits) as a natural number. -/
-def U128x9_as_Nat (limbs : Array U128 9#usize) : Nat :=
-  ∑ i ∈ Finset.range 9, 2^(51 * i) * (limbs[i]!).val
-
 /-- Interpret a 32-element byte array as a natural number. -/
 def U8x32_as_Nat (bytes : Array U8 32#usize) : Nat :=
   ∑ i ∈ Finset.range 32, 2^(8 * i) * (bytes[i]!).val

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/MontgomeryReduce.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/MontgomeryReduce.lean
@@ -49,7 +49,7 @@ natural language specs:
 theorem montgomery_reduce_spec (a : Array U128 9#usize) :
     ∃ m,
     montgomery_reduce a = ok m ∧
-    (Scalar52_as_Nat m * R) % L = U128x9_as_Nat a % L
+    (Scalar52_as_Nat m * R) % L = Scalar52_wide_as_Nat a % L
     := by
   sorry
 


### PR DESCRIPTION
The conversion function

U128x9_as_Nat (limbs : Array U128 9#usize) : Nat :=
 ∑ i ∈ Finset.range 9, 2^(51 * i) * (limbs[i]!).val

has only been employed in one file (other than Defs.lean), namely in MontgomeryReduce.lean. The application of U128x9_as_Nat in MontgomeryReduce.lean to the input 

a : Array U128 9#usize

appears erroneous, however, as U128x9_as_Nat uses base 51, while the input a should be assumed to be (for example) the square of a Scalar52 element, and thus be associated with base 52. 

The correct conversion function in this context thus appears to be Scalar52_wide_as_Nat, which makes the conversion function U128x9_as_Nat redundant. 

I have therefore:

- Removed the unnecessary conversion function U128x9_as_Nat
- Corrected the spec theorem for MontgomeryReduce by plugging in the correct conversion function Scalar52_wide_as_Nat