### PR TITLE
Added from_bytes_wide_spec

### DIFF
--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/FromBytesWide.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/FromBytesWide.lean
@@ -63,7 +63,7 @@ theorem from_bytes_wide_loop_spec
     --newly processed word at index i
     from_bytes_wide_loop bytes words i ⦃ words' =>
     words_as_Nat words' = words_as_Nat words
-      + ∑ j ∈ Finset.Ico i.val 8, word_j_from_bytes bytes j * 2 ^ (64 * j) ⦄ := by
+      + ∑ j ∈ Finset.Ico i.val 8, word_j_from_bytes bytes j * 2 ^ (8 * j) ⦄ := by
   -- We can use the BitList to help us with this proof.
   sorry
 
@@ -80,7 +80,7 @@ theorem from_bytes_wide_spec ( b : Array U8 64#usize ) :
   -- 1. To prove U8x64_as_Nat b = words_as_Nat words1
   --    - From from_bytes_wide_loop_spec, we know that
   --      words_as_Nat words1 = words_as_Nat words
-  --        + ∑ j ∈ Finset.Ico i.val 8, word_j_from_bytes bytes j * 2 ^ (64 * j)
+  --        + ∑ j ∈ Finset.Ico i.val 8, word_j_from_bytes bytes j * 2 ^ (8 * j)
   --    - Since i.val = 0, the RHS = U8x64_as_Nat b.
   --    - Thus, we have U8x64_as_Nat b = words_as_Nat words1.
 


### PR DESCRIPTION
> **NOTE:** This PR only contains informal proof.

### Progress update

1. Commit https://github.com/Beneficial-AI-Foundation/curve25519-dalek-lean-verify/pull/615/commits/2b07683b0e53f369514f71f8105285535078d7bc - Added from_bytes_wide_loop_spec
2. Commit https://github.com/Beneficial-AI-Foundation/curve25519-dalek-lean-verify/pull/615/commits/5f0425227646a9b94527e79ad2f621ec07bcdd92 - Updated imports, fix some defs, came up with overall rough sketch
3. Commit https://github.com/Beneficial-AI-Foundation/curve25519-dalek-lean-verify/pull/615/commits/92c9d3c856e4446d62750eb0aef8ba6ace5a689d - Provided informal proof for from_bytes_wide_spec
4. Commit https://github.com/Beneficial-AI-Foundation/curve25519-dalek-lean-verify/pull/615/commits/1ba341c057242773024aa0331b4df920e8bb3e54 - Fixed small typo on the exponent in from_bytes_wide_loop_spec