### PR TITLE
fix: make bench-pr workflow more robust

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.pr.outputs.ref }}
+          ref: ${{ steps.pr.outputs.sha }}
 
       - name: Install elan
         run: |
@@ -80,16 +80,27 @@ jobs:
           REPO_NAME=$(gh repo view --json nameWithOwner -q .nameWithOwner)
           HEAD_SHA=${{ steps.pr.outputs.sha }}
           BASE_SHA=${{ steps.pr.outputs.base_sha }}
-          REPORT_URL="${{ secrets.BENCH_API_ENDPOINT }}/${REPO_NAME}/${HEAD_SHA}/report/pr?base=${BASE_SHA}"
+          ENDPOINT="${{ secrets.BENCH_API_ENDPOINT }}"
+          REPORT_URL="${ENDPOINT}/${REPO_NAME}/${HEAD_SHA}/report/pr?base=${BASE_SHA}"
 
-          RESPONSE=$(curl -s --show-error -w "\nHTTP_STATUS:%{http_code}" "$REPORT_URL")
+          RESPONSE=$(curl -s --max-time 300 --show-error -w "\nHTTP_STATUS:%{http_code}" "$REPORT_URL")
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
           BODY=$(echo "$RESPONSE" | sed '$d')
 
           if [[ "$HTTP_STATUS" -ne 200 ]]; then
-            echo "Server returned HTTP $HTTP_STATUS"
-            echo "$BODY"
-            exit 1
+            echo "::warning::Report with base SHA ${BASE_SHA} failed (HTTP ${HTTP_STATUS}), retrying with default branch tip"
+            DEFAULT_SHA=$(git rev-parse origin/$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name))
+            REPORT_URL="${ENDPOINT}/${REPO_NAME}/${HEAD_SHA}/report/pr?base=${DEFAULT_SHA}"
+
+            RESPONSE=$(curl -s --max-time 300 --show-error -w "\nHTTP_STATUS:%{http_code}" "$REPORT_URL")
+            HTTP_STATUS=$(echo "$RESPONSE" | tail -1 | sed 's/HTTP_STATUS://')
+            BODY=$(echo "$RESPONSE" | sed '$d')
+
+            if [[ "$HTTP_STATUS" -ne 200 ]]; then
+              echo "Server returned HTTP $HTTP_STATUS"
+              echo "$BODY"
+              exit 1
+            fi
           fi
 
           COMMENT=$(echo "$BODY" | jq -r .markdown)


### PR DESCRIPTION
In PR #734 an issue with the benchmarks came up where it came up that the server was not storing the artifacts correctly and failing to produce a report. This PR fixes these issues:

1. The artifact is stored at the correct SHA. Before it was based on the head ref, now it's the head sha, this was an issue for user workflows with PRs coming in from branches on forks.
2. Attempt to get the report from the server comparing the commit head SHA to the base SHA. If that fails, then fall back to comparing the commit head SHA to the default branch's head SHA.
3. Small tweak with curl timeout. This is unrelated to the previous failures, but could prevent an unexpected failure in the future if the server is under a heavy load and takes long to respond to the report. 