### PR TITLE
ci: grant warning-diff workflow PR comment permissions

### DIFF
--- a/.github/workflows/warning-diff.yml
+++ b/.github/workflows/warning-diff.yml
@@ -7,6 +7,11 @@ on:
       - 'lakefile.lean'
       - 'lean-toolchain'
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   warning-diff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes the CI run job for warning about linters diffs. The default GITHUB_TOKEN is read-only, so the sticky-pull-request-comment step failed with "Resource not accessible by integration" whenever a PR produced a non-empty warning diff.

This closes #806 