### PR TITLE
style: streamline all files in Specs/Field

### DIFF
--- a/Curve25519Dalek/Specs/Field/FieldElement51/InvSqrt.lean
+++ b/Curve25519Dalek/Specs/Field/FieldElement51/InvSqrt.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Dablander, Hoang Le Truong
 -/
@@ -9,91 +9,62 @@ import Curve25519Dalek.Specs.Field.FieldElement51.SqrtRatioi
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ONE
 import Curve25519Dalek.Specs.Backend.Serial.U64.Constants.SqrtM1
 
-/-! # Spec Theorem for `FieldElement51::invsqrt`
+/-!
+# Spec theorem for `curve25519_dalek::field::FieldElement51::invsqrt`
 
-Specification and proof for `FieldElement51::invsqrt`.
+This function takes a field element `v` and returns its (nonnegative) inverse square root
+by feeding `(1, v)` into `sqrt_ratio_i`. Concretely it returns:
 
-This function inputs (1, v) for a field element v into sqrt_ratio_i.
-It computes
+- `(Choice(1), +sqrt(1/v))` if `v` is a nonzero square;
+- `(Choice(0), 0)`          if `v` is zero;
+- `(Choice(0), +sqrt(i/v))` if `v` is a nonzero nonsquare.
 
-- the nonnegative square root of 1/v              when v is a nonzero square,
-- returns zero                                    when v is zero, and
-- returns the nonnegative square root of i/v      when v is a nonzero nonsquare.
+Here `i` represents a square root of `-1` in the field (mod `p`) and is stored as the
+constant `SQRT_M1`. Every returned square root is nonnegative.
 
-Here i = sqrt(-1) = SQRT_M1 constant
-
-Source: curve25519-dalek/src/field.rs
+Source: "curve25519-dalek/src/field.rs"
 -/
 
-open Aeneas Aeneas.Std Aeneas.Std.WP Result
+open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.u64.field.FieldElement51
 open curve25519_dalek.backend.serial.u64.constants
 namespace curve25519_dalek.field.FieldElement51
 
-/-
-Natural language description:
-
-    This function takes a field element v and returns
-
-    - (Choice(1), +sqrt(1/v))    if v is a nonzero square;
-    - (Choice(0), zero)          if v is zero;
-    - (Choice(0), +sqrt(i/v))    if v is a nonzero nonsquare.
-
-Here i represents a square root of -1 in the field (mod p) and is stored as the constant SQRT_M1.
-Every returned square root is nonnegative.
-
-Natural language specs:
-
-    • The function succeeds (no panic) for all field element inputs
-
-    • The result (c, r) satisfies three mutually exclusive cases:
-
-      - If v = 0 (mod p), then (c, r) = (Choice(0), 0)
-
-      - If v ≠ 0 (mod p) and v is a square, then (c, r) = (Choice(1), sqrt(1/v))
-
-      - If v ≠ 0 (mod p) and v is not a square, then (c, r) = (Choice(0), sqrt(i/v))
-
-    • In all cases, r is non-negative
--/
-
-/-- **Spec and proof concerning `field.FieldElement51.invsqrt`**:
-- No panic for field element inputs v (always returns (c, r) successfully)
-- Output limbs bounded by 2^53 - 1
-- Result r is non-negative (r_nat % 2 = 0)
-- The result satisfies exactly one of three mutually exclusive cases:
-  1. If v ≡ 0 (mod p), then c.val = 0 and r ≡ 0 (mod p)
-  2. If v ≢ 0 and ∃ x, x^2 * v ≡ 1 (mod p), then c.val = 1 and r^2 * v ≡ 1 (mod p)
-  3. If v ≢ 0 and ¬∃ x, x^2 * v ≡ 1 (mod p), then c.val = 0 and r^2 * v ≡ SQRT_M1 (mod p)
+/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::invsqrt`**
+• The function succeeds (no panic) for field element inputs `v` with limbs bounded by `2^52 - 1`
+• Output limbs are bounded by `2^53 - 1`
+• The result `r` is non-negative (`r_nat % 2 = 0`)
+• If `v ≡ 0 (mod p)`, then `c.val = 0` and `r ≡ 0 (mod p)`
+• If `v ≢ 0 (mod p)` and `v` is a square, then `c.val = 1` and `r^2 * v ≡ 1 (mod p)`
+• If `v ≢ 0 (mod p)` and `v` is not a square, then `c.val = 0` and `r^2 * v ≡ i (mod p)`
 -/
 @[step]
 theorem invsqrt_spec
     (v : backend.serial.u64.field.FieldElement51)
     (h_v_bounds : ∀ i, i < 5 → (v[i]!).val ≤ 2 ^ 52 - 1) :
-    invsqrt v ⦃ res =>
-    let v_nat := Field51_as_Nat v % p
-    let r_nat := Field51_as_Nat res.snd % p
-    let i_nat := Field51_as_Nat SQRT_M1_val % p
-    -- Unconditional bounds
-    (∀ i < 5, res.snd[i]!.val ≤ 2 ^ 53 - 1) ∧
-    -- Non-negativity
-    (r_nat % 2 = 0) ∧
-    -- Case 1: If v ≡ 0 (mod p), then c.val = 0 and r ≡ 0 (mod p)
-    (v_nat = 0 → res.fst.val = 0#u8 ∧ r_nat = 0) ∧
-    -- Case 2: If v ≢ 0 and ∃ x, x^2 * v ≡ 1 (mod p), then c.val = 1 and r^2 * v ≡ 1 (mod p)
-    (v_nat ≠ 0 ∧ (∃ x : Nat, (x ^ 2 * v_nat) % p = 1) →
-      res.fst.val = 1#u8 ∧ (r_nat ^ 2 * v_nat) % p = 1) ∧
-    -- Case 3: If v ≢ 0 and ¬∃ x, x^2 * v ≡ 1 (mod p), then c.val = 0 and r^2 * v ≡ i (mod p)
-    (v_nat ≠ 0 ∧ ¬(∃ x : Nat, (x ^ 2 * v_nat) % p = 1) →
-      res.fst.val = 0#u8 ∧ (r_nat ^ 2 * v_nat) % p = i_nat) ⦄ := by
-  unfold invsqrt
-    backend.serial.u64.field.FieldElement51.ONE
-    backend.serial.u64.field.FieldElement51.from_limbs
+    invsqrt v ⦃ (result : subtle.Choice × backend.serial.u64.field.FieldElement51) =>
+      let v_nat := Field51_as_Nat v % p
+      let r_nat := Field51_as_Nat result.snd % p
+      let i_nat := Field51_as_Nat SQRT_M1_val % p
+      -- Output limb bounds
+      (∀ i < 5, result.snd[i]!.val ≤ 2 ^ 53 - 1) ∧
+      -- Non-negativity
+      (r_nat % 2 = 0) ∧
+      -- Case 1: If v ≡ 0 (mod p), then c.val = 0 and r ≡ 0 (mod p)
+      (v_nat = 0 → result.fst.val = 0#u8 ∧ r_nat = 0) ∧
+      -- Case 2: If v ≢ 0 and ∃ x, x^2 * v ≡ 1 (mod p), then c.val = 1 and r^2 * v ≡ 1 (mod p)
+      (v_nat ≠ 0 ∧ (∃ x : Nat, (x ^ 2 * v_nat) % p = 1) →
+        result.fst.val = 1#u8 ∧ (r_nat ^ 2 * v_nat) % p = 1) ∧
+      -- Case 3: If v ≢ 0 and ¬∃ x, x^2 * v ≡ 1 (mod p), then c.val = 0 and r^2 * v ≡ i (mod p)
+      (v_nat ≠ 0 ∧ ¬(∃ x : Nat, (x ^ 2 * v_nat) % p = 1) →
+        result.fst.val = 0#u8 ∧ (r_nat ^ 2 * v_nat) % p = i_nat) ⦄ := by
+  unfold invsqrt ONE from_limbs
   simp only [bind_tc_ok]
   step as ⟨c, h_bounds, h_nonneg, h_case1, h_case2, h_case3, h_case4⟩
   · intro i _; interval_cases i; all_goals decide
   -- Rewrite Field51_as_Nat of literal ONE to 1 in all case hypotheses
-  have h_one : Field51_as_Nat (Array.make 5#usize [1#u64, 0#u64, 0#u64, 0#u64, 0#u64]) % p = 1 := by decide
+  have h_one : Field51_as_Nat (Array.make 5#usize [1#u64, 0#u64, 0#u64, 0#u64, 0#u64]) % p = 1 :=
+    by decide
   simp only [h_one] at h_case1 h_case2 h_case3 h_case4
   refine ⟨h_bounds, h_nonneg, ?_, ?_, ?_⟩
   · -- Case 1: v = 0 → Choice(0) ∧ r = 0

--- a/Curve25519Dalek/Specs/Field/FieldElement51/Invert.lean
+++ b/Curve25519Dalek/Specs/Field/FieldElement51/Invert.lean
@@ -1,75 +1,60 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Dablander, Hoang Le Truong
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Field.FieldElement51.Pow22501
-import Curve25519Dalek.Math.Edwards.Curve
-/-! # Spec Theorem for `FieldElement51::invert`
 
-Specification and proof for `FieldElement51::invert`.
+/-!
+# Spec theorem for `curve25519_dalek::field::FieldElement51::invert`
 
-This function computes the multiplicative inverse of a field element r in 𝔽_p where p = 2^255 - 19.
-The inverse is computed as r^(p-2), since r^(p-2) * r = r^(p-1) = 1 (mod p) by Fermat's Little Theorem.
+This function computes the multiplicative inverse of a field element r in 𝔽_p
+where p = 2^255 - 19.
+The inverse is r^(p-2), since r^(p-2) * r = r^(p-1) = 1 (mod p) by Fermat's Little Theorem.
+The field element is represented in radix 2^51 form with five u64 limbs.
 
-This function returns zero on input zero.
-
-**Source**: curve25519-dalek/src/field.rs
-
+Source: "curve25519-dalek/src/field.rs"
 -/
+
+-- Allow kernel reduction of the large numerical exponent `p - 2 = 2^255 - 21`
+-- (and `p - 1` from Fermat's Little Theorem) when typechecking the proof below.
+set_option exponentiation.threshold 100000
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.u64.field.FieldElement51
 open curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithMulSharedAFieldElement51FieldElement51
   (mul_spec)
-namespace curve25519_dalek.field.FieldElement51
-
-/-
-Natural language description:
-
-    • Computes the multiplicative inverse r^(-1) of a field element r in 𝔽_p where p = 2^255 - 19
-    • The inverse is computed as r^(p-2) = r^(2^255-21) using the identity r^(p-2) * r = r^(p-1) = 1 (mod p)
-    • The field element is represented in radix 2^51 form with five u64 limbs
-    • Returns zero when the input is zero
-
-Natural language specs:
-
-    • The function succeeds (no panic)
-    • For any nonzero field element r, the result r' satisfies:
-      - Field51_as_Nat(r') * Field51_as_Nat(r) ≡ 1 (mod p)
-    • For zero input, the result is zero:
-      - Field51_as_Nat(r) ≡ 0 (mod p) → Field51_as_Nat(r') ≡ 0 (mod p)
--/
 
 theorem prime_25519 : Nat.Prime p := by
   have h : Fact (Nat.Prime p) := by infer_instance
   exact h.out
 
 lemma coprime_of_prime_not_dvd {a p : ℕ}
-(hp : p.Prime) (hpa : ¬ p ∣ a) : Nat.Coprime a p := by
+    (hp : p.Prime) (hpa : ¬ p ∣ a) : Nat.Coprime a p := by
   have hgp_div_p : gcd a p ∣ p := gcd_dvd_right a p
   rcases (Nat.dvd_prime hp).1 hgp_div_p with hgp1 | hgp2
   · simpa [Nat.Coprime, hgp1]
   · have : p ∣ a := by simpa [hgp2] using gcd_dvd_left a p
     exact (hpa this).elim
 
-set_option exponentiation.threshold 100000
+namespace curve25519_dalek.field.FieldElement51
 
-/-- **Spec and proof concerning `field.FieldElement51.invert`**:
-- No panic for field element inputs r (always returns r' successfully)
-- If r ≢ 0 (mod p), then Field51_as_Nat(r') * Field51_as_Nat(r) ≡ 1 (mod p)
-- If r ≡ 0 (mod p), then Field51_as_Nat(r') ≡ 0 (mod p)
+/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::invert`**
+• No panic when each input limb of r satisfies `r[i].val < 2 ^ 54`
+  (always returns r' successfully)
+• If r ≢ 0 (mod p), then Field51_as_Nat(r') * Field51_as_Nat(r) ≡ 1 (mod p)
+• If r ≡ 0 (mod p), then Field51_as_Nat(r') ≡ 0 (mod p)
+• The output limbs satisfy `r'[i].val < 2^52` for all `i < 5`
 -/
 @[step]
 theorem invert_spec (r : backend.serial.u64.field.FieldElement51)
     (h_bounds : ∀ i, i < 5 → (r[i]!).val < 2 ^ 54) :
     invert r ⦃ (r' : backend.serial.u64.field.FieldElement51) =>
-      let r_nat := Field51_as_Nat r % p
-      let r'_nat := Field51_as_Nat r' % p
-      (r_nat ≠ 0 → (r'_nat * r_nat) % p = 1) ∧
-      (r_nat = 0 → r'_nat = 0) ∧
+      (Field51_as_Nat r % p ≠ 0 →
+        (Field51_as_Nat r' % p * (Field51_as_Nat r % p)) % p = 1) ∧
+      (Field51_as_Nat r % p = 0 → Field51_as_Nat r' % p = 0) ∧
       (∀ i, i < 5 → (r'[i]!).val < 2 ^ 52) ⦄ := by
   unfold invert
   -- invert = pow22501 → pow2k(t19, 5) → mul(t20, t3)
@@ -91,8 +76,7 @@ theorem invert_spec (r : backend.serial.u64.field.FieldElement51)
   · -- Zero case: r ≡ 0 (mod p) means p ∣ r, hence p ∣ r^(p-2), so r^(p-2) % p = 0
     rw [Nat.ModEq] at hpow
     rw [hpow]
-    exact (Nat.dvd_iff_mod_eq_zero).mp
+    exact Nat.dvd_iff_mod_eq_zero.mp
       (dvd_pow (Nat.dvd_of_mod_eq_zero h0) (by unfold p; omega))
-
 
 end curve25519_dalek.field.FieldElement51

--- a/Curve25519Dalek/Specs/Field/FieldElement51/IsNegative.lean
+++ b/Curve25519Dalek/Specs/Field/FieldElement51/IsNegative.lean
@@ -1,51 +1,36 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ToBytes
+
 /-!
-# Spec Theorem for `FieldElement51::is_negative`
+# Spec theorem for `curve25519_dalek::field::FieldElement51::is_negative`
 
-Specification and proof for `FieldElement51::is_negative`.
-
-This function checks whether a field element is "negative" in the sense used by
+For a field element `r` in 𝔽_p, represented in radix 2^51 (five `u64` limbs),
+this function checks whether `r` is "negative" in the sense used by
 curve25519-dalek, namely whether the least significant bit of its canonical
 little-endian encoding is set. Concretely, it returns the LSB of the first byte
-of `to_bytes(self)` as a `subtle.Choice`.
+of `to_bytes(self)` as a `subtle.Choice` (0 = even, 1 = odd).
 
 Mathematically, this corresponds to the parity of the canonical representative
 of the residue modulo `p = 2^255 - 19`.
 
-**Source**: curve25519-dalek/src/field.rs
+Source: "curve25519-dalek/src/field.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-namespace curve25519_dalek.field.FieldElement51
 
-/-!
-Natural language description:
-
-- For a field element `r` in 𝔽_p, represented in radix 2^51 (five u64 limbs),
-  compute the least significant bit of its canonical encoding
-  (equivalently, the parity of `Field51_as_Nat(r) % p`).
-- Returns a `subtle.Choice` (0 = even, 1 = odd).
-
-Spec:
-
-- Function succeeds (no panic).
-- For any field element `r`, the result `c` satisfies
-  `c.val = 1 ↔ (Field51_as_Nat(r) % p) % 2 = 1`.
--/
-
-/-- **Spec and proof concerning `FieldElement51.is_negative`.** -/
-theorem first_bit (bytes : Aeneas.Std.Array U8 32#usize) :
-    U8x32_as_Nat bytes  % 2 = (bytes.val[0]).val %2 := by
-  rw[← Nat.ModEq]
+/-- The parity of `U8x32_as_Nat bytes` equals the parity of its zeroth byte's value. -/
+theorem U8x32_as_Nat_mod_two_eq_zeroth_byte_val_mod_two
+    (bytes : Array U8 32#usize) :
+    U8x32_as_Nat bytes % 2 = (bytes.val[0]).val % 2 := by
+  rw [← Nat.ModEq]
   apply Nat.ModEq.symm
-  rw[Nat.modEq_iff_dvd]
+  rw [Nat.modEq_iff_dvd]
   unfold U8x32_as_Nat
   simp only [Nat.cast_ofNat, Array.getElem!_Nat_eq, List.getElem!_eq_getElem?_getD,
     Finset.sum_range_succ, Finset.range_one, Finset.sum_singleton, mul_zero, pow_zero,
@@ -54,10 +39,17 @@ theorem first_bit (bytes : Aeneas.Std.Array U8 32#usize) :
     Nat.cast_add, Nat.cast_mul]
   scalar_tac
 
+namespace curve25519_dalek.field.FieldElement51
+
+/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::is_negative`**
+• The function always succeeds (no panic).
+• The result `c` satisfies `c.val = 1` iff the canonical representative of the
+  field element modulo `p = 2^255 - 19` is odd.
+-/
 @[step]
-theorem is_negative_spec (r : backend.serial.u64.field.FieldElement51) :
-    is_negative r ⦃ c =>
-    (c.val = 1#u8 ↔ (Field51_as_Nat r % p) % 2 = 1) ⦄ := by
+theorem is_negative_spec (self : backend.serial.u64.field.FieldElement51) :
+    is_negative self ⦃ (c : subtle.Choice) =>
+      (c.val = 1#u8 ↔ (Field51_as_Nat self % p) % 2 = 1) ⦄ := by
   unfold is_negative
   step as ⟨bytes, h_mod, h_lt⟩
   step as ⟨b0⟩
@@ -82,7 +74,7 @@ theorem is_negative_spec (r : backend.serial.u64.field.FieldElement51) :
     rw [Nat.ModEq] at h_mod
     rw [← h_mod]
     have := Nat.mod_eq_of_lt h_lt
-    simp only [this, first_bit]
+    simp only [this, U8x32_as_Nat_mod_two_eq_zeroth_byte_val_mod_two]
     exact h_i1
   · step*
     simp_all only [UScalar.ofNatCore_val_eq, ReduceNat.reduceNatEq, U8.ofNat_bv,
@@ -92,7 +84,7 @@ theorem is_negative_spec (r : backend.serial.u64.field.FieldElement51) :
     rw [Nat.ModEq] at h_mod
     rw [← h_mod]
     have := Nat.mod_eq_of_lt h_lt
-    simp only [this, first_bit]
+    simp only [this, U8x32_as_Nat_mod_two_eq_zeroth_byte_val_mod_two]
     exact h_i1
 
 end curve25519_dalek.field.FieldElement51

--- a/Curve25519Dalek/Specs/Field/FieldElement51/IsZero.lean
+++ b/Curve25519Dalek/Specs/Field/FieldElement51/IsZero.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Dablander, Hoang Le Truong
 -/
@@ -9,36 +9,19 @@ import Curve25519Dalek.Aux
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Reduce
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ToBytes
 
-set_option linter.style.longLine false
-set_option linter.style.setOption false
-
 /-!
-# Spec Theorem for `FieldElement51::is_zero`
+# Spec theorem for `curve25519_dalek::field::FieldElement51::is_zero`
 
-Specification and proof for `FieldElement51::is_zero`.
+For an input field element in 𝔽_p (where `p = 2^255 - 19`), represented in
+radix 2^51 with five `u64` limbs, this function checks whether it represents
+the zero element of the field. It returns a `subtle.Choice` (0 = false,
+1 = true) indicating whether the canonical representative modulo `p`
+equals zero.
 
-This function checks whether a field element is zero.
-
-**Source**: curve25519-dalek/src/field.rs
+Source: "curve25519-dalek/src/field.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-
-namespace curve25519_dalek.field.FieldElement51
-
-/-!
-Natural language description:
-
-- Checks whether a field element is zero in 𝔽_p, p = 2^255 - 19.
-- Field element is in radix 2^51 with five u64 limbs.
-- Returns a `subtle.Choice` (0 = false, 1 = true).
-
-Spec:
-
-- Function succeeds (no panic).
-- For any field element `r`, result `c` satisfies
-  `c.val = 1 ↔ Field51_as_Nat(r) % p = 0`.
--/
 
 /-- Arrays are equal if their slices are equal. -/
 lemma array_eq_of_to_slice_eq {α : Type} {n : Usize} {h1 h2 : Array α n}
@@ -50,7 +33,7 @@ lemma array_eq_of_to_slice_eq {α : Type} {n : Usize} {h1 h2 : Array α n}
   cases h
   rfl
 
-/-! ## Workaround for `step` timeout
+/-- Opaque wrapper around `Prop` used as a workaround for a `step`-tactic timeout.
 
 The `step` tactic runs `simp` on **all hypotheses** in the context. After `step`
 processes `to_bytes`, the postconditions involving `U8x32_as_Nat` / `Field51_as_Nat` are
@@ -62,23 +45,28 @@ Workaround:
    without touching hypotheses (bypasses `step` for those steps).
 2. Wrap the expensive hypotheses in `Hold` (opaque to `simp`) before calling `step`
    on `ct_eq`.
-3. Recover with `change ... at` afterwards (`Hold P` is defeq to `P`).
--/
-
+3. Recover with `change ... at` afterwards (`Hold P` is defeq to `P`). -/
 private def Hold (P : Prop) : Prop := P
 
+namespace curve25519_dalek.field.FieldElement51
+
+/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::is_zero`**
+• The function always succeeds (no panic).
+• The result `c` satisfies `c.val = 1#u8` iff the canonical representative of
+  the field element modulo `p = 2^255 - 19` equals zero.
+-/
 @[step]
-theorem is_zero_spec (r : backend.serial.u64.field.FieldElement51) :
-    is_zero r ⦃ c =>
-    (c.val = 1#u8 ↔ Field51_as_Nat r % p = 0) ⦄ := by
+theorem is_zero_spec (self : backend.serial.u64.field.FieldElement51) :
+    is_zero self ⦃ (c : subtle.Choice) =>
+      (c.val = 1#u8 ↔ Field51_as_Nat self % p = 0) ⦄ := by
   unfold is_zero
   step as ⟨bytes, h_to_bytes_mod, h_to_bytes_lt⟩
   simp only [lift, bind_tc_ok] at ⊢
-  have h_mod : Hold (U8x32_as_Nat bytes ≡ Field51_as_Nat r [MOD p]) := h_to_bytes_mod
+  have h_mod : Hold (U8x32_as_Nat bytes ≡ Field51_as_Nat self [MOD p]) := h_to_bytes_mod
   have h_lt : Hold (U8x32_as_Nat bytes < p) := h_to_bytes_lt
   clear h_to_bytes_mod h_to_bytes_lt
   step as ⟨result, h_ct_eq⟩
-  change U8x32_as_Nat bytes ≡ Field51_as_Nat r [MOD p] at h_mod
+  change U8x32_as_Nat bytes ≡ Field51_as_Nat self [MOD p] at h_mod
   change U8x32_as_Nat bytes < p at h_lt
   -- Step 6: prove the iff
   constructor

--- a/Curve25519Dalek/Specs/Field/FieldElement51/Pow22501.lean
+++ b/Curve25519Dalek/Specs/Field/FieldElement51/Pow22501.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Dablander, Hoang Le Truong
 -/
@@ -8,22 +8,19 @@ import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Pow2K
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Square
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
-/-! # Spec Theorem for `FieldElement51::pow22501`
 
-Specification and proof for `FieldElement51::pow22501`.
+/-!
+# Spec theorem for `curve25519_dalek::field::FieldElement51::pow22501`
 
 This function computes (r^(2^250-1), r^11) for a field element r in 𝔽_p where p = 2^255 - 19.
 
-**Source**: curve25519-dalek/src/field.rs
+Source: "curve25519-dalek/src/field.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.u64.field.FieldElement51
 open curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithMulSharedAFieldElement51FieldElement51
   (mul_spec)
-namespace curve25519_dalek.field.FieldElement51
-
-set_option exponentiation.threshold 100000
 
 /-! ### Helper lemmas for exponent chain reasoning
 
@@ -45,21 +42,28 @@ lemma chain_pow2k {r a b e k m : ℕ}
     b ≡ r ^ (e * 2 ^ k) [MOD m] :=
   hb.trans ((ha.pow (2 ^ k)).trans (by rw [← pow_mul]))
 
-/-- **Spec and proof concerning `field.FieldElement51.pow22501`**:
-- No panic (always returns (r1, r2) successfully)
-- Field51_as_Nat(r1) ≡ Field51_as_Nat(r)^(2^250-1) (mod p)
-  Field51_as_Nat(r2) ≡ Field51_as_Nat(r)^11 (mod p)
+namespace curve25519_dalek.field.FieldElement51
+
+set_option exponentiation.threshold 100000
+
+/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::pow22501`**
+• No panic (always returns (r1, r2) successfully)
+• Field51_as_Nat(r1) ≡ Field51_as_Nat(self)^(2^250-1) (mod p)
+• Field51_as_Nat(r2) ≡ Field51_as_Nat(self)^11 (mod p)
+• Each limb of r1 is bounded by 2^52
+• Each limb of r2 is bounded by 2^52
 -/
 @[step]
-theorem pow22501_spec (r : backend.serial.u64.field.FieldElement51)
-    (h_bounds : ∀ i, i < 5 → (r[i]!).val < 2 ^ 54) :
-    pow22501 r ⦃ result =>
-    let r1 := result.1
-    let r2 := result.2
-    Field51_as_Nat r1 % p = (Field51_as_Nat r ^ (2 ^ 250 - 1)) % p ∧
-    Field51_as_Nat r2 % p = (Field51_as_Nat r ^ 11) % p ∧
-    (∀ i, i < 5 → (r1[i]!).val < 2 ^ 52) ∧
-    (∀ i, i < 5 → (r2[i]!).val < 2 ^ 52) ⦄ := by
+theorem pow22501_spec (self : backend.serial.u64.field.FieldElement51)
+    (h_bounds : ∀ i, i < 5 → (self[i]!).val < 2 ^ 54) :
+    pow22501 self ⦃ (result : backend.serial.u64.field.FieldElement51 ×
+        backend.serial.u64.field.FieldElement51) =>
+      let r1 := result.1
+      let r2 := result.2
+      Field51_as_Nat r1 % p = (Field51_as_Nat self ^ (2 ^ 250 - 1)) % p ∧
+      Field51_as_Nat r2 % p = (Field51_as_Nat self ^ 11) % p ∧
+      (∀ i, i < 5 → (r1[i]!).val < 2 ^ 52) ∧
+      (∀ i, i < 5 → (r2[i]!).val < 2 ^ 52) ⦄ := by
   unfold pow22501
   -- Step through the 21 field operations with explicit spec theorems.
   -- Bounds preconditions are auto-solved by step.
@@ -84,14 +88,14 @@ theorem pow22501_spec (r : backend.serial.u64.field.FieldElement51)
   step with mul_spec as ⟨ t17, ht17, ht17b ⟩
   step with pow2k_spec as ⟨ t18, ht18, ht18b ⟩
   step with mul_spec as ⟨ t19, ht19, ht19b ⟩
-  -- Chain modular congruences: each step computes the exponent of r.
+  -- Chain modular congruences: each step computes the exponent of self.
   -- Exponents: t0→2, fe→4, t1→8, t2→9, t3→11, t4→22, t5→31,
   --   t6→992, t7→1023, ..., t19→(2^250-1)
-  have exp_r : Field51_as_Nat r ≡ (Field51_as_Nat r) ^ 1 [MOD p] := by rw [pow_one]
-  have exp_t0 := chain_sq exp_r ht0
+  have exp_self : Field51_as_Nat self ≡ (Field51_as_Nat self) ^ 1 [MOD p] := by rw [pow_one]
+  have exp_t0 := chain_sq exp_self ht0
   have exp_fe := chain_sq exp_t0 hfe
   have exp_t1 := chain_sq exp_fe ht1
-  have exp_t2 := chain_mul exp_r exp_t1 ht2
+  have exp_t2 := chain_mul exp_self exp_t1 ht2
   have exp_t3 := chain_mul exp_t0 exp_t2 ht3
   have exp_t4 := chain_sq exp_t3 ht4
   have exp_t5 := chain_mul exp_t2 exp_t4 ht5

--- a/Curve25519Dalek/Specs/Field/FieldElement51/PowP58.lean
+++ b/Curve25519Dalek/Specs/Field/FieldElement51/PowP58.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Dablander, Hoang Le Truong
 -/
@@ -9,14 +9,13 @@ import Curve25519Dalek.Specs.Field.FieldElement51.Pow22501
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Pow2K
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
 
-/-! # Spec Theorem for `FieldElement51::pow_p58`
+/-!
+# Spec theorem for `curve25519_dalek::field::FieldElement51::pow_p58`
 
-Specification and proof for `FieldElement51::pow_p58`.
+This function computes `r^((p-5)/8)` for a field element `r` in `𝔽_p` where `p = 2^255 - 19`,
+and thus `(p-5)/8 = 2^252 - 3`.
 
-This function computes r^((p-5)/8) for a field element r in 𝔽_p where p = 2^255 - 19
-and thus (p-5)/8 = 2^252 -3
-
-**Source**: curve25519-dalek/src/field.rs
+Source: "curve25519-dalek/src/field.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
@@ -28,12 +27,17 @@ namespace curve25519_dalek.field.FieldElement51
 /-- The exponent `(p-5)/8 = 2^252 - 3`, used in the pow_p58 computation. -/
 def pow_p58_exp : Nat := 2 ^ 252 - 3
 
+/-- Unfolding lemma for `pow_p58_exp`, exposing its underlying value `2^252 - 3`.
+Needed because `pow_p58_exp` is marked irreducible below, which blocks definitional
+unfolding in tactics such as `rw`. -/
 theorem pow_p58_exp_def : pow_p58_exp = 2 ^ 252 - 3 := rfl
 
 attribute [irreducible] pow_p58_exp
 
-/-- **Spec theroem for `field.FieldElement51.pow_p58`**:
-- Field51_as_Nat(result) ≡ Field51_as_Nat(self)^(2^252-3) (mod p)
+/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::pow_p58`**
+• The function never panics, given that each limb of `self` is bounded by `2^52 - 1`
+• `Field51_as_Nat(result) ≡ Field51_as_Nat(self) ^ (2^252 - 3) (mod p)`
+• Each limb of the result is bounded by `2^52`
 -/
 @[step]
 theorem pow_p58_spec (self : FieldElement51) (h_bounds : ∀ i, i < 5 → (self[i]!).val ≤ 2 ^ 52 - 1) :

--- a/Curve25519Dalek/Specs/Field/FieldElement51/SqrtRatioi.lean
+++ b/Curve25519Dalek/Specs/Field/FieldElement51/SqrtRatioi.lean
@@ -1,12 +1,11 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Dablander, Hoang Le Truong, Alessandro D'Angelo
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Math.Edwards.Curve
-
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Square
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
 import Curve25519Dalek.Specs.Field.FieldElement51.PowP58
@@ -18,24 +17,23 @@ import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Conditional
 import Curve25519Dalek.Specs.Backend.Serial.U64.Constants.SqrtM1
 import Curve25519Dalek.Specs.Field.FieldElement51.Invert
 import Curve25519Dalek.Specs.Field.FieldElement51.IsZero
-/-! # Spec Theorem for `FieldElement51::sqrt_ratio_i`
 
-Specification and proof for `FieldElement51::sqrt_ratio_i`.
+/-!
+# Spec theorem for `curve25519_dalek::field::FieldElement51::sqrt_ratio_i`
 
 This function computes a nonnegative square root of u/v or i*u/v
 (where i = sqrt(-1) = SQRT_M1 constant),
 returning a flag indicating which case occurred and handling zero inputs specially.
 
-**Source**: curve25519-dalek/src/field.rs
+Source: "curve25519-dalek/src/field.rs"
 -/
 
-attribute [-simp] Int.reducePow Nat.reducePow
-
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-open curve25519_dalek.backend.serial.u64
+open curve25519_dalek.backend.serial.u64 curve25519_dalek.math
 open curve25519_dalek.backend.serial.u64.field.FieldElement51
-open curve25519_dalek.math
 namespace curve25519_dalek.field.FieldElement51
+
+attribute [-simp] Int.reducePow Nat.reducePow
 
 /-- Algebraic identity used in sqrt_ratio_i: collecting powers of u and v. -/
 private theorem sqrt_ratio_collect (u v e : Nat) :
@@ -53,20 +51,25 @@ private theorem sqrt_ratio_rearrange (u v e : Nat) :
 /-- The SQRT_M1 constant as a plain FieldElement51 (alias for `constants.SQRT_M1_raw`). -/
 def SQRT_M1_val := backend.serial.u64.constants.SQRT_M1_raw
 
-theorem SQRT_M1_val_spec : (Field51_as_Nat SQRT_M1_val)^2 % p = p - 1 := by
+/-- The square of `SQRT_M1_val` reduces to `p - 1` modulo `p`. -/
+private theorem SQRT_M1_val_spec : (Field51_as_Nat SQRT_M1_val)^2 % p = p - 1 := by
   unfold SQRT_M1_val constants.SQRT_M1_raw; decide
 
+/-- If a power is zero modulo the prime `p`, then the base itself is zero modulo `p`. -/
 private theorem modEq_zero_of_pow_modEq_zero {a k : ℕ}
     (h : a ^ k ≡ 0 [MOD p]) :
     a ≡ 0 [MOD p] := by
   rw [Nat.modEq_zero_iff_dvd] at h ⊢
   exact prime_25519.dvd_of_dvd_pow h
 
+/-- `SQRT_M1_val` squared is congruent to `p - 1` modulo `p`. -/
 private theorem sqrt_m1_sq_modEq :
     Field51_as_Nat SQRT_M1_val ^ 2 ≡ p - 1 [MOD p] := by
   simp [Nat.ModEq, SQRT_M1_val_spec]
 
-theorem nat_sqrt_m1_sq_of_add_modeq_zero {a b : ℕ}
+/-- If `a + b ≡ 0 [MOD p]`, then `a ≡ (SQRT_M1_val)^2 * b [MOD p]`
+(since `(SQRT_M1_val)^2 ≡ -1`). -/
+private theorem nat_sqrt_m1_sq_of_add_modeq_zero {a b : ℕ}
   (h : a + b ≡ 0 [MOD p]) :
   a ≡ (Field51_as_Nat SQRT_M1_val) ^ 2 * b [MOD p] := by
   have h_sqrt_eq : (Field51_as_Nat SQRT_M1_val) ^ 2 % p = p - 1 :=
@@ -90,7 +93,8 @@ theorem nat_sqrt_m1_sq_of_add_modeq_zero {a b : ℕ}
   simp only [zero_add] at h6
   exact h6.trans (h1.symm)
 
-theorem eq_to_bytes_eq_Field51_as_Nat
+/-- Equal `to_bytes` outputs imply equal underlying field-element values modulo `p`. -/
+private theorem eq_to_bytes_eq_Field51_as_Nat
     {u v : backend.serial.u64.field.FieldElement51}
     (h : u.to_bytes = v.to_bytes) :
   Field51_as_Nat u % p = Field51_as_Nat v % p := by
@@ -108,7 +112,8 @@ theorem eq_to_bytes_eq_Field51_as_Nat
     exact (Nat.ModEq.symm h1).trans h2
   simpa only [Nat.ModEq] using huv_mod
 
-lemma zero_mod_lt_zero {u p : ℕ} (hu_lt : u < p) (hu_mod : u ≡ 0 [MOD p]) :
+/-- A value below `p` that is congruent to `0` modulo `p` must be exactly `0`. -/
+private lemma zero_mod_lt_zero {u p : ℕ} (hu_lt : u < p) (hu_mod : u ≡ 0 [MOD p]) :
     u = 0 := by
     rw[Nat.ModEq] at hu_mod
     simp only [Nat.zero_mod] at hu_mod
@@ -117,7 +122,8 @@ lemma zero_mod_lt_zero {u p : ℕ} (hu_lt : u < p) (hu_mod : u ≡ 0 [MOD p]) :
     simp only [ReduceNat.reduceNatEq] at this
     exact this
 
-theorem to_bytes_zero_of_Field51_as_Nat_zero
+/-- A field element representing `0` modulo `p` serializes to the all-zero byte array. -/
+private theorem to_bytes_zero_of_Field51_as_Nat_zero
     {u : backend.serial.u64.field.FieldElement51}
     (h : Field51_as_Nat u % p = 0) :
    u.to_bytes = ok (Array.repeat 32#usize 0#u8)  := by
@@ -144,7 +150,8 @@ theorem to_bytes_zero_of_Field51_as_Nat_zero
   rw [← hru_eq]
   exact hu
 
-theorem SQRT_M1_not_square (x : ℕ) :
+/-- `SQRT_M1` is not a square in `ZMod p`: no natural number `x` satisfies `x^4 ≡ -1 [MOD p]`. -/
+private theorem SQRT_M1_not_square (x : ℕ) :
   ¬ (x ^ 4 ≡ p - 1 [MOD p]) := by
   intro hx
   have hx_z : ((x : ZMod p) ^ 4) = (-1 : ZMod p) := by
@@ -176,7 +183,9 @@ theorem SQRT_M1_not_square (x : ℕ) :
           ring
   exact _root_.curve25519_dalek.math.sqrt_m1_not_square hsquare
 
-lemma zero_of_mul_SQRT_M1_zero {a : ℕ} (ha : a * Field51_as_Nat SQRT_M1_val ≡ 0 [MOD p]) :
+/-- If `a * SQRT_M1_val ≡ 0 [MOD p]`, then `a ≡ 0 [MOD p]` (since `SQRT_M1_val` is a unit). -/
+private lemma zero_of_mul_SQRT_M1_zero {a : ℕ}
+    (ha : a * Field51_as_Nat SQRT_M1_val ≡ 0 [MOD p]) :
   a ≡ 0 [MOD p] := by
   have eq:= ha.mul_right (Field51_as_Nat SQRT_M1_val)
   simp only [mul_assoc, zero_mul] at eq
@@ -193,7 +202,8 @@ lemma zero_of_mul_SQRT_M1_zero {a : ℕ} (ha : a * Field51_as_Nat SQRT_M1_val �
     simp
   apply eq.symm.trans this
 
-theorem pow_div_two_eq_neg_one_or_one {a : ℕ} (ha : ¬ a ≡ 0 [MOD p]) :
+/-- For nonzero `a` mod `p`, `a^((p-1)/2)` is either `1` or `p - 1` modulo `p` (Euler criterion). -/
+private theorem pow_div_two_eq_neg_one_or_one {a : ℕ} (ha : ¬ a ≡ 0 [MOD p]) :
     a ^ ((p -1) / 2) ≡ 1 [MOD p]∨ a ^ ((p-1) / 2) ≡ p - 1 [MOD p] := by
     have : (a ^ ((p -1) / 2) + (p -1)) * (a ^ ((p-1) / 2) +1) ≡ 0 [MOD p] := by
       have : (a ^ ((p -1) / 2) + (p -1)) * (a ^ ((p-1) / 2) +1)
@@ -232,7 +242,9 @@ theorem pow_div_two_eq_neg_one_or_one {a : ℕ} (ha : ¬ a ≡ 0 [MOD p]) :
       simp[this] at r
       simp[r]
 
-theorem pow_div_four_eq_four_cases {a : ℕ} (ha : ¬ a ≡ 0 [MOD p]) :
+/-- For nonzero `a` mod `p`, `a^((p-1)/4)` lies in the four-element group
+generated by `SQRT_M1_val` (i.e. equals `1`, `i`, `-1`, or `-i` modulo `p`). -/
+private theorem pow_div_four_eq_four_cases {a : ℕ} (ha : ¬ a ≡ 0 [MOD p]) :
     a ^ ((p -1) / 4) ≡ 1 [MOD p] ∨
     a ^ ((p-1) / 4) ≡ Field51_as_Nat SQRT_M1_val [MOD p] ∨
     a ^ ((p-1) / 4) ≡ (Field51_as_Nat SQRT_M1_val)^2 [MOD p] ∨
@@ -351,6 +363,7 @@ theorem pow_div_four_eq_four_cases {a : ℕ} (ha : ¬ a ≡ 0 [MOD p]) :
     have r:= r.trans this
     simp [r]
 
+/-- If `a + b ≡ 0 [MOD p]` and `a mod p` is odd, then `b mod p` is even (uses oddness of `p`). -/
 private theorem nonneg_of_neg_mod_p (a b : ℕ)
     (h_sum : (a + b) % p = 0) (h_a_odd : a % p % 2 = 1) :
     b % p % 2 = 0 := by
@@ -1316,22 +1329,19 @@ end sqrt_ratio_i_branch_solvers
 
 attribute [local irreducible] p
 
-
 set_option maxHeartbeats 400000 in -- the proof works even with 230k heartbeats, but not much less.
-/-- Spec for `FieldElement51::sqrt_ratio_i`: computes a nonnegative square root of u/v or
-i*u/v (where i = sqrt(-1) = SQRT_M1), returning a flag indicating which case occurred.
-
-Returns `(Choice(1), +sqrt(u/v))` if u/v is square, `(Choice(1), 0)` if u=0,
-`(Choice(0), 0)` if v=0 and u≠0, `(Choice(0), +sqrt(i*u/v))` if u/v is nonsquare.
-
-Postconditions (4 mutually exclusive cases + non-negativity):
-1. u ≡ 0 → c=1, r≡0
-2. u≢0, v≡0 → c=0, r≡0
-3. u≢0, v≢0, ∃x, x²v≡u → c=1, r²v≡u
-4. u≢0, v≢0, ¬∃x, x²v≡u → c=0, r²v≡SQRT_M1·u
-5. r is non-negative (r % p % 2 = 0)
+/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::sqrt_ratio_i`**
+(auxiliary existential form, used internally to derive `sqrt_ratio_i_spec`).
+• The function succeeds (no panic) for limb-bounded inputs `u, v` with limbs `< 2^54`
+• If `u ≡ 0 (mod p)`, then `c.1 = 1` and `r ≡ 0 (mod p)`
+• If `u ≢ 0` and `v ≡ 0 (mod p)`, then `c.1 = 0` and `r ≡ 0 (mod p)`
+• If `u ≢ 0`, `v ≢ 0`, and `u/v` is a square, then `c.1 = 1` and `r^2 * v ≡ u (mod p)`
+• If `u ≢ 0`, `v ≢ 0`, and `u/v` is not a square, then `c.1 = 0` and
+  `r^2 * v ≡ SQRT_M1 * u (mod p)`
+• The output limbs satisfy `c.2[i] ≤ 2^53 - 1`
+• The result `r` is non-negative (`r % p % 2 = 0`)
 -/
-theorem sqrt_ratio_i_spec'
+private theorem sqrt_ratio_i_spec'
     (u : backend.serial.u64.field.FieldElement51)
     (v : backend.serial.u64.field.FieldElement51)
     (h_u_bounds : ∀ i, i < 5 → (u[i]!).val < 2 ^ 54)
@@ -1386,7 +1396,8 @@ theorem sqrt_ratio_i_spec'
   let* ⟨ flipped_sign_sqrt, flipped_sign_sqrt_post ⟩ ← Insts.SubtleConstantTimeEq.ct_eq_spec
   let* ⟨ fe7, fe7_post1, fe7_post2 ⟩ ←
     Shared0FieldElement51.Insts.CoreOpsArithMulSharedAFieldElement51FieldElement51.mul_spec
-  let* ⟨ flipped_sign_sqrt_i, flipped_sign_sqrt_i_post ⟩ ← Insts.SubtleConstantTimeEq.ct_eq_spec
+  let* ⟨ flipped_sign_sqrt_i, flipped_sign_sqrt_i_post ⟩ ←
+    Insts.SubtleConstantTimeEq.ct_eq_spec
   let* ⟨ r_prime, r_prime_post1, r_prime_post2 ⟩ ←
     Shared0FieldElement51.Insts.CoreOpsArithMulSharedAFieldElement51FieldElement51.mul_spec
   -- Bridge: i = SQRT_M1_raw, fold back to SQRT_M1_val
@@ -1537,29 +1548,37 @@ theorem sqrt_ratio_i_spec'
               r2_post r_is_negative_post
               h_check_ne_u h_check_ne_fe6 h_check_ne_fe7
 
-
+/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::sqrt_ratio_i`**
+• The function succeeds (no panic) for limb-bounded inputs `u, v` with limbs `< 2^54`
+• Output limbs are bounded by `2^53 - 1`
+• The result `r` is non-negative (`r_nat % 2 = 0`)
+• If `u ≡ 0 (mod p)`, then `c.1 = 1` and `r ≡ 0 (mod p)`
+• If `u ≢ 0` and `v ≡ 0 (mod p)`, then `c.1 = 0` and `r ≡ 0 (mod p)`
+• If `u ≢ 0`, `v ≢ 0`, and `u/v` is a square, then `c.1 = 1` and `r^2 * v ≡ u (mod p)`
+• If `u ≢ 0`, `v ≢ 0`, and `u/v` is not a square, then `c.1 = 0` and
+  `r^2 * v ≡ SQRT_M1 * u (mod p)`
+-/
 @[step]
 theorem sqrt_ratio_i_spec
     (u : backend.serial.u64.field.FieldElement51)
     (v : backend.serial.u64.field.FieldElement51)
     (h_u_bounds : ∀ i, i < 5 → (u[i]!).val < 2 ^ 54)
     (h_v_bounds : ∀ i, i < 5 → (v[i]!).val < 2 ^ 54) :
-    sqrt_ratio_i u v ⦃ c =>
-    let u_nat := Field51_as_Nat u % p
-    let v_nat := Field51_as_Nat v % p
-    let r_nat := Field51_as_Nat c.2 % p
-    let i_nat := Field51_as_Nat SQRT_M1_val % p
-    (∀ i < 5,  c.2[i]!.val ≤ 2 ^ 53 - 1) ∧
-    (r_nat % 2 = 0) ∧
-    (u_nat = 0 →
-      c.1.val = 1#u8 ∧ r_nat = 0) ∧
-    (u_nat ≠ 0 ∧ v_nat = 0 →
-      c.1.val = 0#u8 ∧ r_nat = 0) ∧
-    (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (∃ x : Nat, (x^2 * v_nat) % p = u_nat) →
-      c.1.val = 1#u8 ∧ (r_nat ^ 2 * v_nat) % p = u_nat) ∧
-    (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (¬(∃ x : Nat, (x^2 * v_nat) % p = u_nat)) →
-      c.1.val = 0#u8 ∧ (r_nat ^2 * v_nat) % p = (i_nat * u_nat) % p)
-    ⦄ := by
+    sqrt_ratio_i u v ⦃ (c : subtle.Choice × backend.serial.u64.field.FieldElement51) =>
+      let u_nat := Field51_as_Nat u % p
+      let v_nat := Field51_as_Nat v % p
+      let r_nat := Field51_as_Nat c.2 % p
+      let i_nat := Field51_as_Nat SQRT_M1_val % p
+      (∀ i < 5,  c.2[i]!.val ≤ 2 ^ 53 - 1) ∧
+      (r_nat % 2 = 0) ∧
+      (u_nat = 0 →
+        c.1.val = 1#u8 ∧ r_nat = 0) ∧
+      (u_nat ≠ 0 ∧ v_nat = 0 →
+        c.1.val = 0#u8 ∧ r_nat = 0) ∧
+      (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (∃ x : Nat, (x^2 * v_nat) % p = u_nat) →
+        c.1.val = 1#u8 ∧ (r_nat ^ 2 * v_nat) % p = u_nat) ∧
+      (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (¬(∃ x : Nat, (x^2 * v_nat) % p = u_nat)) →
+        c.1.val = 0#u8 ∧ (r_nat ^2 * v_nat) % p = (i_nat * u_nat) % p) ⦄ := by
   have ⟨c, h_ok, h1, h2, h3, h4, h_nonneg⟩ := sqrt_ratio_i_spec' u v h_u_bounds h_v_bounds
   exact exists_imp_spec ⟨c, h_ok, by
     refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
@@ -1580,6 +1599,7 @@ theorem sqrt_ratio_i_spec
     · -- Case 3
       intro ⟨hu, hv, hqr⟩; exact ⟨(h3 ⟨hu, hv, hqr⟩).1, (h3 ⟨hu, hv, hqr⟩).2.1⟩
     · -- Case 4
-      intro ⟨hu, hv, hnqr⟩; exact ⟨(h4 ⟨hu, hv, hnqr⟩).1, (h4 ⟨hu, hv, hnqr⟩).2.1⟩⟩
+      intro ⟨hu, hv, hnqr⟩
+      exact ⟨(h4 ⟨hu, hv, hnqr⟩).1, (h4 ⟨hu, hv, hnqr⟩).2.1⟩⟩
 
 end curve25519_dalek.field.FieldElement51

--- a/Curve25519Dalek/Specs/Field/FieldElement51/SqrtRatioi.lean
+++ b/Curve25519Dalek/Specs/Field/FieldElement51/SqrtRatioi.lean
@@ -30,7 +30,7 @@ Source: "curve25519-dalek/src/field.rs"
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.u64 curve25519_dalek.math
-open curve25519_dalek.backend.serial.u64.field.FieldElement51
+  curve25519_dalek.backend.serial.u64.field.FieldElement51
 namespace curve25519_dalek.field.FieldElement51
 
 attribute [-simp] Int.reducePow Nat.reducePow
@@ -49,10 +49,10 @@ private theorem sqrt_ratio_rearrange (u v e : Nat) :
       ((v ^ (2 + 1)) ^ 2 * v ^ (((2 + 1) * 2 + 1) * (e * 2)) * v) := by ring
 
 /-- The SQRT_M1 constant as a plain FieldElement51 (alias for `constants.SQRT_M1_raw`). -/
-def SQRT_M1_val := backend.serial.u64.constants.SQRT_M1_raw
+def SQRT_M1_val : field.FieldElement51 := constants.SQRT_M1_raw
 
 /-- The square of `SQRT_M1_val` reduces to `p - 1` modulo `p`. -/
-private theorem SQRT_M1_val_spec : (Field51_as_Nat SQRT_M1_val)^2 % p = p - 1 := by
+private theorem SQRT_M1_val_spec : (Field51_as_Nat SQRT_M1_val) ^ 2 % p = p - 1 := by
   unfold SQRT_M1_val constants.SQRT_M1_raw; decide
 
 /-- If a power is zero modulo the prime `p`, then the base itself is zero modulo `p`. -/
@@ -70,8 +70,8 @@ private theorem sqrt_m1_sq_modEq :
 /-- If `a + b ≡ 0 [MOD p]`, then `a ≡ (SQRT_M1_val)^2 * b [MOD p]`
 (since `(SQRT_M1_val)^2 ≡ -1`). -/
 private theorem nat_sqrt_m1_sq_of_add_modeq_zero {a b : ℕ}
-  (h : a + b ≡ 0 [MOD p]) :
-  a ≡ (Field51_as_Nat SQRT_M1_val) ^ 2 * b [MOD p] := by
+    (h : a + b ≡ 0 [MOD p]) :
+    a ≡ (Field51_as_Nat SQRT_M1_val) ^ 2 * b [MOD p] := by
   have h_sqrt_eq : (Field51_as_Nat SQRT_M1_val) ^ 2 % p = p - 1 :=
     SQRT_M1_val_spec
   have h_sqrt_mod : (Field51_as_Nat SQRT_M1_val) ^ 2 ≡ p - 1 [MOD p] := by
@@ -80,24 +80,24 @@ private theorem nat_sqrt_m1_sq_of_add_modeq_zero {a b : ℕ}
     exact h_sqrt_mod.mul_right b
   have hp_pos : 1 ≤ p := by unfold p; simp [Nat.reducePow]
   have h2 : (p - 1) * b = p * b - b := by
-      rw [Nat.sub_mul _ _ _, Nat.one_mul]
-  have h3 : 0 ≡ p * b  [MOD p] := by
+    rw [Nat.sub_mul _ _ _, Nat.one_mul]
+  have h3 : 0 ≡ p * b [MOD p] := by
     simp only [Nat.ModEq, Nat.zero_mod, Nat.mul_mod_right]
-  have : p *b =  b + (p-1) *b  := by unfold p; omega
-  rw[this] at h3
-  have h4:=h3.add_left a
-  have : a + (b + (p - 1) * b) =(a + b) + (p - 1) * b := by omega
+  have : p * b = b + (p - 1) * b := by unfold p; omega
+  rw [this] at h3
+  have h4 := h3.add_left a
+  have : a + (b + (p - 1) * b) = (a + b) + (p - 1) * b := by omega
   simp only [add_zero, this] at h4
-  have h5:=h.add_right ((p - 1) * b)
-  have h6:=h4.trans h5
+  have h5 := h.add_right ((p - 1) * b)
+  have h6 := h4.trans h5
   simp only [zero_add] at h6
   exact h6.trans (h1.symm)
 
 /-- Equal `to_bytes` outputs imply equal underlying field-element values modulo `p`. -/
 private theorem eq_to_bytes_eq_Field51_as_Nat
-    {u v : backend.serial.u64.field.FieldElement51}
+    {u v : field.FieldElement51}
     (h : u.to_bytes = v.to_bytes) :
-  Field51_as_Nat u % p = Field51_as_Nat v % p := by
+    Field51_as_Nat u % p = Field51_as_Nat v % p := by
   classical
   obtain ⟨ru, hu, hru_mod, _⟩ := spec_imp_exists (to_bytes_spec u)
   obtain ⟨rv, hv, hrv_mod, _⟩ := spec_imp_exists (to_bytes_spec v)
@@ -115,23 +115,23 @@ private theorem eq_to_bytes_eq_Field51_as_Nat
 /-- A value below `p` that is congruent to `0` modulo `p` must be exactly `0`. -/
 private lemma zero_mod_lt_zero {u p : ℕ} (hu_lt : u < p) (hu_mod : u ≡ 0 [MOD p]) :
     u = 0 := by
-    rw[Nat.ModEq] at hu_mod
-    simp only [Nat.zero_mod] at hu_mod
-    have : u % p = u := Nat.mod_eq_of_lt hu_lt
-    rw[hu_mod] at this
-    simp only [ReduceNat.reduceNatEq] at this
-    exact this
+  rw [Nat.ModEq] at hu_mod
+  simp only [Nat.zero_mod] at hu_mod
+  have : u % p = u := Nat.mod_eq_of_lt hu_lt
+  rw [hu_mod] at this
+  simp only [ReduceNat.reduceNatEq] at this
+  exact this
 
 /-- A field element representing `0` modulo `p` serializes to the all-zero byte array. -/
 private theorem to_bytes_zero_of_Field51_as_Nat_zero
-    {u : backend.serial.u64.field.FieldElement51}
+    {u : field.FieldElement51}
     (h : Field51_as_Nat u % p = 0) :
-   u.to_bytes = ok (Array.repeat 32#usize 0#u8)  := by
+    u.to_bytes = ok (Array.repeat 32#usize 0#u8) := by
   classical
   obtain ⟨ru, hu, hru_mod, hru_lt⟩ := spec_imp_exists (to_bytes_spec u)
-  rw[← modEq_zero_iff] at h
+  rw [← modEq_zero_iff] at h
   have := hru_mod.trans h
-  have h_bytes_zero:= zero_mod_lt_zero hru_lt this
+  have h_bytes_zero := zero_mod_lt_zero hru_lt this
   obtain ⟨c, c_ok, hc ⟩  := spec_imp_exists (is_zero_spec u)
   have hru_eq : ru = Array.repeat 32#usize 0#u8 := by
     unfold U8x32_as_Nat at h_bytes_zero
@@ -152,180 +152,181 @@ private theorem to_bytes_zero_of_Field51_as_Nat_zero
 
 /-- `SQRT_M1` is not a square in `ZMod p`: no natural number `x` satisfies `x^4 ≡ -1 [MOD p]`. -/
 private theorem SQRT_M1_not_square (x : ℕ) :
-  ¬ (x ^ 4 ≡ p - 1 [MOD p]) := by
+    ¬ (x ^ 4 ≡ p - 1 [MOD p]) := by
   intro hx
   have hx_z : ((x : ZMod p) ^ 4) = (-1 : ZMod p) := by
     have hcast : (((x ^ 4 : ℕ)) : ZMod p) = ((p - 1 : ℕ) : ZMod p) := by
       exact (ZMod.natCast_eq_natCast_iff _ _ _).2 (by simpa [Nat.ModEq] using hx)
     push_cast at hcast
-    rwa [_root_.curve25519_dalek.math.p_sub_one_cast] at hcast
+    rwa [p_sub_one_cast] at hcast
   have hx_sq :
-      (((x : ZMod p) ^ 2) ^ 2) = _root_.curve25519_dalek.math.sqrt_m1 ^ 2 := by
+      (((x : ZMod p) ^ 2) ^ 2) = sqrt_m1 ^ 2 := by
     calc
       (((x : ZMod p) ^ 2) ^ 2) = ((x : ZMod p) ^ 4) := by
         rw [show 4 = 2 * 2 by norm_num, pow_mul]
       _ = (-1 : ZMod p) := hx_z
-      _ = _root_.curve25519_dalek.math.sqrt_m1 ^ 2 := by
-        rw [_root_.curve25519_dalek.math.sqrt_m1_sq]
-  have hsquare : IsSquare (_root_.curve25519_dalek.math.sqrt_m1) := by
+      _ = sqrt_m1 ^ 2 := by
+        rw [sqrt_m1_sq]
+  have hsquare : IsSquare (sqrt_m1) := by
     rcases sq_eq_sq_iff_eq_or_eq_neg.mp hx_sq with hroot | hroot
     · refine ⟨(x : ZMod p), ?_⟩
       simpa [pow_two] using hroot.symm
-    · refine ⟨(x : ZMod p) * _root_.curve25519_dalek.math.sqrt_m1, ?_⟩
+    · refine ⟨(x : ZMod p) * sqrt_m1, ?_⟩
       calc
-        _root_.curve25519_dalek.math.sqrt_m1 =
-            (-_root_.curve25519_dalek.math.sqrt_m1) * (-1 : ZMod p) := by
+        sqrt_m1 =
+            (-sqrt_m1) * (-1 : ZMod p) := by
           ring
-        _ = ((x : ZMod p) ^ 2) * (_root_.curve25519_dalek.math.sqrt_m1 ^ 2) := by
-          rw [hroot, _root_.curve25519_dalek.math.sqrt_m1_sq]
-        _ = ((x : ZMod p) * _root_.curve25519_dalek.math.sqrt_m1) *
-              ((x : ZMod p) * _root_.curve25519_dalek.math.sqrt_m1) := by
+        _ = ((x : ZMod p) ^ 2) * (sqrt_m1 ^ 2) := by
+          rw [hroot, sqrt_m1_sq]
+        _ = ((x : ZMod p) * sqrt_m1) *
+              ((x : ZMod p) * sqrt_m1) := by
           ring
-  exact _root_.curve25519_dalek.math.sqrt_m1_not_square hsquare
+  exact sqrt_m1_not_square hsquare
 
 /-- If `a * SQRT_M1_val ≡ 0 [MOD p]`, then `a ≡ 0 [MOD p]` (since `SQRT_M1_val` is a unit). -/
 private lemma zero_of_mul_SQRT_M1_zero {a : ℕ}
     (ha : a * Field51_as_Nat SQRT_M1_val ≡ 0 [MOD p]) :
-  a ≡ 0 [MOD p] := by
-  have eq:= ha.mul_right (Field51_as_Nat SQRT_M1_val)
+    a ≡ 0 [MOD p] := by
+  have eq := ha.mul_right (Field51_as_Nat SQRT_M1_val)
   simp only [mul_assoc, zero_mul] at eq
-  have : Field51_as_Nat SQRT_M1_val * Field51_as_Nat SQRT_M1_val ≡ p-1 [MOD p] := by
+  have : Field51_as_Nat SQRT_M1_val * Field51_as_Nat SQRT_M1_val ≡ p - 1 [MOD p] := by
     simpa only [pow_two] using sqrt_m1_sq_modEq
-  have eq:= ((this.mul_left a).symm.trans eq).add_right a
-  rw[(by simp : 0 +a =a)] at eq
-  have : a * (p - 1) + a= p * a := by
+  have eq := ((this.mul_left a).symm.trans eq).add_right a
+  rw [(by simp : 0 + a = a)] at eq
+  have : a * (p - 1) + a = p * a := by
     unfold p
     omega
-  rw[this] at eq
-  have : p * a ≡ 0  [MOD p] := by
-    rw[Nat.ModEq]
+  rw [this] at eq
+  have : p * a ≡ 0 [MOD p] := by
+    rw [Nat.ModEq]
     simp
   apply eq.symm.trans this
 
-/-- For nonzero `a` mod `p`, `a^((p-1)/2)` is either `1` or `p - 1` modulo `p` (Euler criterion). -/
+/-- For nonzero `a` mod `p`, `a^((p - 1)/2)` is either `1` or `p - 1` modulo `p`
+(Euler criterion). -/
 private theorem pow_div_two_eq_neg_one_or_one {a : ℕ} (ha : ¬ a ≡ 0 [MOD p]) :
-    a ^ ((p -1) / 2) ≡ 1 [MOD p]∨ a ^ ((p-1) / 2) ≡ p - 1 [MOD p] := by
-    have : (a ^ ((p -1) / 2) + (p -1)) * (a ^ ((p-1) / 2) +1) ≡ 0 [MOD p] := by
-      have : (a ^ ((p -1) / 2) + (p -1)) * (a ^ ((p-1) / 2) +1)
-        = a ^ ((p -1) ) + p * a ^ ((p -1) / 2) + (p-1) := by
-        rw[mul_add, add_mul, (fun a => by ring : ∀ a, a * a = a^2), ← pow_mul]
-        simp only [mul_one, ← add_assoc, Nat.add_right_cancel_iff]
-        simp only [add_assoc,
-          (by ring :
-              (p - 1) * a ^ ((p - 1) / 2) + a ^ ((p - 1) / 2) = ((p - 1) + 1) * a ^ ((p - 1) / 2))]
-        have : p-1 +1 =p := by unfold p; omega
-        rw[this]
-        have : (p-1)/2 *2 =p-1 := by unfold p; omega
-        rw[this]
-      rw[this]
-      rw[Nat.modEq_zero_iff_dvd] at ha
-      have := coprime_of_prime_not_dvd prime_25519 ha
-      have fermat:= Nat.ModEq.pow_card_sub_one_eq_one prime_25519 this
-      have :p * a ^ ((p - 1) / 2) ≡ 0 [MOD p] := by
-        rw[Nat.modEq_zero_iff_dvd]
-        simp
-      have := (fermat.add this).add_right (p-1)
-      apply this.trans
-      have : 1 + 0 + (p - 1) =p := by unfold p; omega
-      rw[this]
-      rw[Nat.modEq_zero_iff_dvd]
-    have := mul_zero_eq_or (hp := prime_25519) this
-    rcases this with r | l
-    · have r:= r.add_right 1
-      rw[add_assoc] at r
-      have : p-1 +1 =p := by unfold p; omega
-      simp[this] at r
-      simp[r]
-    · have r:= l.add_right (p-1)
-      rw[add_assoc] at r
-      have :  1 + (p-1) =p := by unfold p; omega
-      simp[this] at r
-      simp[r]
+    a ^ ((p - 1) / 2) ≡ 1 [MOD p] ∨ a ^ ((p - 1) / 2) ≡ p - 1 [MOD p] := by
+  have : (a ^ ((p - 1) / 2) + (p - 1)) * (a ^ ((p - 1) / 2) + 1) ≡ 0 [MOD p] := by
+    have : (a ^ ((p - 1) / 2) + (p - 1)) * (a ^ ((p - 1) / 2) + 1)
+      = a ^ (p - 1) + p * a ^ ((p - 1) / 2) + (p - 1) := by
+      rw [mul_add, add_mul, (fun a => by ring : ∀ a, a * a = a ^ 2), ← pow_mul]
+      simp only [mul_one, ← add_assoc, Nat.add_right_cancel_iff]
+      simp only [add_assoc,
+        (by ring :
+            (p - 1) * a ^ ((p - 1) / 2) + a ^ ((p - 1) / 2) = ((p - 1) + 1) * a ^ ((p - 1) / 2))]
+      have : p - 1 + 1 = p := by unfold p; omega
+      rw [this]
+      have : (p - 1) / 2 * 2 = p - 1 := by unfold p; omega
+      rw [this]
+    rw [this]
+    rw [Nat.modEq_zero_iff_dvd] at ha
+    have := coprime_of_prime_not_dvd prime_25519 ha
+    have fermat := Nat.ModEq.pow_card_sub_one_eq_one prime_25519 this
+    have : p * a ^ ((p - 1) / 2) ≡ 0 [MOD p] := by
+      rw [Nat.modEq_zero_iff_dvd]
+      simp
+    have := (fermat.add this).add_right (p - 1)
+    apply this.trans
+    have : 1 + 0 + (p - 1) = p := by unfold p; omega
+    rw [this]
+    rw [Nat.modEq_zero_iff_dvd]
+  have := mul_zero_eq_or (hp := prime_25519) this
+  rcases this with r | l
+  · have r := r.add_right 1
+    rw [add_assoc] at r
+    have : p - 1 + 1 = p := by unfold p; omega
+    simp [this] at r
+    simp [r]
+  · have r := l.add_right (p - 1)
+    rw [add_assoc] at r
+    have : 1 + (p - 1) = p := by unfold p; omega
+    simp [this] at r
+    simp [r]
 
-/-- For nonzero `a` mod `p`, `a^((p-1)/4)` lies in the four-element group
+/-- For nonzero `a` mod `p`, `a^((p - 1)/4)` lies in the four-element group
 generated by `SQRT_M1_val` (i.e. equals `1`, `i`, `-1`, or `-i` modulo `p`). -/
 private theorem pow_div_four_eq_four_cases {a : ℕ} (ha : ¬ a ≡ 0 [MOD p]) :
-    a ^ ((p -1) / 4) ≡ 1 [MOD p] ∨
-    a ^ ((p-1) / 4) ≡ Field51_as_Nat SQRT_M1_val [MOD p] ∨
-    a ^ ((p-1) / 4) ≡ (Field51_as_Nat SQRT_M1_val)^2 [MOD p] ∨
-    a ^ ((p-1) / 4) ≡ (Field51_as_Nat SQRT_M1_val)^3 [MOD p] := by
-  have eq1:  (a ^ ((p -1) / 4) + (p-1)) *
-          (a ^ ((p -1) / 4) + 1)
+    a ^ ((p - 1) / 4) ≡ 1 [MOD p] ∨
+    a ^ ((p - 1) / 4) ≡ Field51_as_Nat SQRT_M1_val [MOD p] ∨
+    a ^ ((p - 1) / 4) ≡ (Field51_as_Nat SQRT_M1_val) ^ 2 [MOD p] ∨
+    a ^ ((p - 1) / 4) ≡ (Field51_as_Nat SQRT_M1_val) ^ 3 [MOD p] := by
+  have eq1 : (a ^ ((p - 1) / 4) + (p - 1)) *
+          (a ^ ((p - 1) / 4) + 1)
            =
-          a ^ ((p -1)/2 ) + p * a ^ ((p -1) / 4) + (p-1)
+          a ^ ((p - 1) / 2) + p * a ^ ((p - 1) / 4) + (p - 1)
            := by
-        rw[mul_add, add_mul, (fun a => by ring : ∀ a, a * a = a^2), ← pow_mul]
+        rw [mul_add, add_mul, (fun a => by ring : ∀ a, a * a = a ^ 2), ← pow_mul]
         simp only [mul_one, ← add_assoc, Nat.add_right_cancel_iff]
         simp only [add_assoc,
           (by ring :
               (p - 1) * a ^ ((p - 1) / 4) + a ^ ((p - 1) / 4) = ((p - 1) + 1) * a ^ ((p - 1) / 4))]
-        have : p-1 +1 =p := by unfold p; omega
-        rw[this]
-        have : (p-1)/4 *2 =(p-1)/2 := by unfold p; omega
-        rw[this]
-  have eq2:  (a ^ ((p -1) / 4) + (p-1)* (Field51_as_Nat SQRT_M1_val)) * (a ^ ((p -1) / 4)
-          + Field51_as_Nat SQRT_M1_val) = a ^ ((p -1)/2 ) + p * a ^ ((p -1) / 4)
-          * (Field51_as_Nat SQRT_M1_val) + (p-1) *
+        have : p - 1 + 1 = p := by unfold p; omega
+        rw [this]
+        have : (p - 1) / 4 * 2 = (p - 1) / 2 := by unfold p; omega
+        rw [this]
+  have eq2 : (a ^ ((p - 1) / 4) + (p - 1) * (Field51_as_Nat SQRT_M1_val)) * (a ^ ((p - 1) / 4)
+          + Field51_as_Nat SQRT_M1_val) = a ^ ((p - 1) / 2) + p * a ^ ((p - 1) / 4)
+          * (Field51_as_Nat SQRT_M1_val) + (p - 1) *
           Field51_as_Nat SQRT_M1_val * Field51_as_Nat SQRT_M1_val := by
-        rw[mul_add, add_mul,add_mul, (fun a => by ring : ∀ a, a * a = a^2), ← pow_mul]
-        rw[← add_assoc]
+        rw [mul_add, add_mul, add_mul, (fun a => by ring : ∀ a, a * a = a ^ 2), ← pow_mul]
+        rw [← add_assoc]
         simp only [add_assoc,
           (by ring :
               (p - 1) * (Field51_as_Nat SQRT_M1_val) * a ^ ((p - 1) / 4) +
                   a ^ ((p - 1) / 4) * Field51_as_Nat SQRT_M1_val =
                 ((p - 1) + 1) * a ^ ((p - 1) / 4) * Field51_as_Nat SQRT_M1_val)]
-        have : p-1 +1 =p := by unfold p; omega
+        have : p - 1 + 1 = p := by unfold p; omega
         rw [this]
-        have : (p-1)/4 *2 =(p-1)/2 := by unfold p; omega
-        rw[this, ← add_assoc]
-  have : (a ^ ((p -1) / 4) + (p-1)) *
-          (a ^ ((p -1) / 4) + 1) *
-          (a ^ ((p -1) / 4) + (p-1)* (Field51_as_Nat SQRT_M1_val)) *
-          (a ^ ((p -1) / 4) + Field51_as_Nat SQRT_M1_val)
+        have : (p - 1) / 4 * 2 = (p - 1) / 2 := by unfold p; omega
+        rw [this, ← add_assoc]
+  have : (a ^ ((p - 1) / 4) + (p - 1)) *
+          (a ^ ((p - 1) / 4) + 1) *
+          (a ^ ((p - 1) / 4) + (p - 1) * (Field51_as_Nat SQRT_M1_val)) *
+          (a ^ ((p - 1) / 4) + Field51_as_Nat SQRT_M1_val)
           ≡ 0 [MOD p] := by
           simp only [eq1, mul_assoc, eq2]
-          have eq1:a ^ ((p -1)/2 ) + p * a ^ ((p -1) / 4) + (p-1) ≡
-            a ^ ((p -1)/2 ) + (p-1)
+          have eq1 : a ^ ((p - 1) / 2) + p * a ^ ((p - 1) / 4) + (p - 1) ≡
+            a ^ ((p - 1) / 2) + (p - 1)
             [MOD p] := by
-            simp[Nat.modEq_iff_dvd]
+            simp [Nat.modEq_iff_dvd]
           have : a ^ ((p - 1) / 2) + p * (a ^ ((p - 1) / 4) * Field51_as_Nat SQRT_M1_val) +
             (p - 1) * (Field51_as_Nat SQRT_M1_val * Field51_as_Nat SQRT_M1_val) ≡
-            a ^ ((p -1)/2 ) + 1
+            a ^ ((p - 1) / 2) + 1
             [MOD p] := by
             have : (p - 1) * (Field51_as_Nat SQRT_M1_val * Field51_as_Nat SQRT_M1_val) ≡
-                1 [MOD p]:= by
+                1 [MOD p] := by
               unfold SQRT_M1_val
               decide
             have := this.add_left
               (a ^ ((p - 1) / 2) + p * (a ^ ((p - 1) / 4) * Field51_as_Nat SQRT_M1_val))
             apply Nat.ModEq.trans this
-            simp[Nat.modEq_iff_dvd]
+            simp [Nat.modEq_iff_dvd]
           apply (eq1.mul this).trans
-          have : (a ^ ((p -1) / 2) + (p -1)) * (a ^ ((p-1) / 2) +1) ≡ 0 [MOD p] := by
-            have : (a ^ ((p -1) / 2) + (p -1)) * (a ^ ((p-1) / 2) +1)
-              = a ^ ((p -1) ) + p * a ^ ((p -1) / 2) + (p-1) := by
-              rw[mul_add, add_mul, (fun a => by ring : ∀ a, a * a = a^2), ← pow_mul]
+          have : (a ^ ((p - 1) / 2) + (p - 1)) * (a ^ ((p - 1) / 2) + 1) ≡ 0 [MOD p] := by
+            have : (a ^ ((p - 1) / 2) + (p - 1)) * (a ^ ((p - 1) / 2) + 1)
+              = a ^ (p - 1) + p * a ^ ((p - 1) / 2) + (p - 1) := by
+              rw [mul_add, add_mul, (fun a => by ring : ∀ a, a * a = a ^ 2), ← pow_mul]
               simp only [mul_one, ← add_assoc, Nat.add_right_cancel_iff]
               simp only [add_assoc,
                 (by ring :
                     (p - 1) * a ^ ((p - 1) / 2) + a ^ ((p - 1) / 2) =
                       ((p - 1) + 1) * a ^ ((p - 1) / 2))]
-              have : p-1 +1 =p := by unfold p; omega
-              rw[this]
-              have : (p-1)/2 *2 =p-1 := by unfold p; omega
-              rw[this]
-            rw[this]
-            rw[Nat.modEq_zero_iff_dvd] at ha
+              have : p - 1 + 1 = p := by unfold p; omega
+              rw [this]
+              have : (p - 1) / 2 * 2 = p - 1 := by unfold p; omega
+              rw [this]
+            rw [this]
+            rw [Nat.modEq_zero_iff_dvd] at ha
             have := coprime_of_prime_not_dvd prime_25519 ha
-            have fermat:= Nat.ModEq.pow_card_sub_one_eq_one prime_25519 this
-            have :p * a ^ ((p - 1) / 2) ≡ 0 [MOD p] := by
-              rw[Nat.modEq_zero_iff_dvd]
+            have fermat := Nat.ModEq.pow_card_sub_one_eq_one prime_25519 this
+            have : p * a ^ ((p - 1) / 2) ≡ 0 [MOD p] := by
+              rw [Nat.modEq_zero_iff_dvd]
               simp
-            have := (fermat.add this).add_right (p-1)
+            have := (fermat.add this).add_right (p - 1)
             apply this.trans
-            have : 1 + 0 + (p - 1) =p := by unfold p; omega
-            rw[this]
-            rw[Nat.modEq_zero_iff_dvd]
+            have : 1 + 0 + (p - 1) = p := by unfold p; omega
+            rw [this]
+            rw [Nat.modEq_zero_iff_dvd]
           apply this
   have := mul_zero_eq_or (hp := prime_25519) this
   rcases this with hl | hl
@@ -333,34 +334,34 @@ private theorem pow_div_four_eq_four_cases {a : ℕ} (ha : ¬ a ≡ 0 [MOD p]) :
     rcases this with hl | hl
     · have := mul_zero_eq_or (hp := prime_25519) hl
       rcases this with hl | hl
-      · have r:= hl.add_right 1
-        rw[add_assoc] at r
-        have : p-1 +1 =p := by unfold p; omega
-        simp[this] at r
-        simp[r]
-      · have r:= hl.add_right (p-1)
-        rw[add_assoc] at r
-        have :  1 + (p-1) =p := by unfold p; omega
+      · have r := hl.add_right 1
+        rw [add_assoc] at r
+        have : p - 1 + 1 = p := by unfold p; omega
+        simp [this] at r
+        simp [r]
+      · have r := hl.add_right (p - 1)
+        rw [add_assoc] at r
+        have : 1 + (p - 1) = p := by unfold p; omega
         simp only [this, zero_add, Nat.add_modulus_modEq_iff] at r
-        have :p - 1  ≡Field51_as_Nat SQRT_M1_val ^2  [MOD p]:= by
-              exact sqrt_m1_sq_modEq.symm
-        have r:= r.trans this
-        simp[r]
-    · have r:= hl.add_right (Field51_as_Nat SQRT_M1_val)
-      rw[add_assoc] at r
-      have : (p-1) * Field51_as_Nat SQRT_M1_val + Field51_as_Nat SQRT_M1_val =
+        have : p - 1 ≡ Field51_as_Nat SQRT_M1_val ^ 2 [MOD p] := by
+          exact sqrt_m1_sq_modEq.symm
+        have r := r.trans this
+        simp [r]
+    · have r := hl.add_right (Field51_as_Nat SQRT_M1_val)
+      rw [add_assoc] at r
+      have : (p - 1) * Field51_as_Nat SQRT_M1_val + Field51_as_Nat SQRT_M1_val =
         p * (Field51_as_Nat SQRT_M1_val) := by unfold p; omega
-      simp[this] at r
-      simp[r]
-  · have r:= hl.add_right ((p-1)*Field51_as_Nat SQRT_M1_val)
-    rw[add_assoc] at r
-    have :  Field51_as_Nat SQRT_M1_val + (p-1) * Field51_as_Nat SQRT_M1_val
+      simp [this] at r
+      simp [r]
+  · have r := hl.add_right ((p - 1) * Field51_as_Nat SQRT_M1_val)
+    rw [add_assoc] at r
+    have :  Field51_as_Nat SQRT_M1_val + (p - 1) * Field51_as_Nat SQRT_M1_val
       = p * (Field51_as_Nat SQRT_M1_val) := by unfold p; omega
     simp only [this, zero_add, Nat.add_modulus_mul_modEq_iff] at r
-    have : (p - 1) * (Field51_as_Nat SQRT_M1_val)  ≡Field51_as_Nat SQRT_M1_val ^3  [MOD p]:= by
-              unfold SQRT_M1_val
-              decide
-    have r:= r.trans this
+    have : (p - 1) * (Field51_as_Nat SQRT_M1_val) ≡ Field51_as_Nat SQRT_M1_val ^ 3 [MOD p] := by
+      unfold SQRT_M1_val
+      decide
+    have r := r.trans this
     simp [r]
 
 /-- If `a + b ≡ 0 [MOD p]` and `a mod p` is odd, then `b mod p` is even (uses oddness of `p`). -/
@@ -396,7 +397,7 @@ private theorem nonneg_of_neg_mod_p (a b : ℕ)
 
 /-- Whole-element `Field51_as_Nat` equality from pointwise limb-value equality. -/
 private theorem field51_as_Nat_eq_of_pointwise_eq
-    {x y : backend.serial.u64.field.FieldElement51}
+    {x y : field.FieldElement51}
     (hxy : ∀ i < 5, x[i]!.val = y[i]!.val) :
     Field51_as_Nat x = Field51_as_Nat y := by
   unfold Field51_as_Nat
@@ -406,7 +407,7 @@ private theorem field51_as_Nat_eq_of_pointwise_eq
 
 /-- Whole-element consequence of a limbwise `conditional_assign` postcondition. -/
 private theorem field51_as_Nat_conditional_assign
-    (x y z : backend.serial.u64.field.FieldElement51)
+    (x y z : field.FieldElement51)
     (c : subtle.Choice)
     (z_post : ∀ i < 5, z[i]! = if c.val = 1#u8 then y[i]! else x[i]!) :
     Field51_as_Nat z =
@@ -429,7 +430,7 @@ private theorem field51_as_Nat_conditional_assign
 
 /-- Whole-element consequence of taking the right branch in `conditional_assign`. -/
 private theorem field51_as_Nat_conditional_assign_eq_right
-    (x y z : backend.serial.u64.field.FieldElement51)
+    (x y z : field.FieldElement51)
     (c : subtle.Choice)
     (hc : c.val = 1#u8)
     (z_post : ∀ i < 5, z[i]! = if c.val = 1#u8 then y[i]! else x[i]!) :
@@ -439,7 +440,7 @@ private theorem field51_as_Nat_conditional_assign_eq_right
 
 /-- Whole-element consequence of taking the left branch in `conditional_assign`. -/
 private theorem field51_as_Nat_conditional_assign_eq_left
-    (x y z : backend.serial.u64.field.FieldElement51)
+    (x y z : field.FieldElement51)
     (c : subtle.Choice)
     (hc : c.val ≠ 1#u8)
     (z_post : ∀ i < 5, z[i]! = if c.val = 1#u8 then y[i]! else x[i]!) :
@@ -449,7 +450,7 @@ private theorem field51_as_Nat_conditional_assign_eq_left
 
 /-- Convert a pointwise postcondition into whole-element equality on `Field51_as_Nat`. -/
 private theorem field51_as_Nat_eq_of_post
-    (base x : backend.serial.u64.field.FieldElement51)
+    (base x : field.FieldElement51)
     (x_post : ∀ i < 5, x[i]! = base[i]!) :
     Field51_as_Nat x = Field51_as_Nat base := by
   refine field51_as_Nat_eq_of_pointwise_eq ?_
@@ -459,7 +460,7 @@ private theorem field51_as_Nat_eq_of_post
 
 /-- `conditional_negate` preserves the represented square modulo `p`. -/
 private theorem conditional_negate_sq
-    (r1 x r2 : backend.serial.u64.field.FieldElement51)
+    (r1 x r2 : field.FieldElement51)
     (r_is_negative : subtle.Choice)
     (x_post_1 : Field51_as_Nat r1 + Field51_as_Nat x ≡ 0 [MOD p])
     (r2_post : ∀ i < 5, r2[i]! = if r_is_negative.val = 1#u8 then x[i]! else r1[i]!) :
@@ -477,7 +478,7 @@ private theorem conditional_negate_sq
 
 /-- After `conditional_negate`, the result `r2` is always non-negative (even mod p). -/
 private theorem conditional_negate_nonneg
-    (r1 x r2 : backend.serial.u64.field.FieldElement51)
+    (r1 x r2 : field.FieldElement51)
     (r_is_negative : subtle.Choice)
     (r_is_negative_post : r_is_negative.val = 1#u8 ↔ Field51_as_Nat r1 % p % 2 = 1)
     (x_post_1 : Field51_as_Nat r1 + Field51_as_Nat x ≡ 0 [MOD p])
@@ -500,7 +501,7 @@ private theorem conditional_negate_nonneg
 
 /-- Limb bounds after `conditional_negate`: either the negated value or the original value. -/
 private theorem conditional_negate_bounds_of_eq
-    (base r1 x r2 : backend.serial.u64.field.FieldElement51)
+    (base r1 x r2 : field.FieldElement51)
     (r_is_negative : subtle.Choice)
     (r1_post : ∀ i < 5, r1[i]! = base[i]!)
     (base_bounds : ∀ i < 5, base[i]!.val < 2 ^ 52)
@@ -526,7 +527,7 @@ private theorem conditional_negate_bounds_of_eq
 
 /-- Common square-preservation branch pattern after `conditional_negate`. -/
 private theorem conditional_negate_sq_mul_eq_of_modeq
-    (base r1 x r2 : backend.serial.u64.field.FieldElement51)
+    (base r1 x r2 : field.FieldElement51)
     (r_is_negative : subtle.Choice)
     (b rhs : ℕ)
     (r1_eq : Field51_as_Nat r1 = Field51_as_Nat base)
@@ -541,7 +542,7 @@ private theorem conditional_negate_sq_mul_eq_of_modeq
 
 /-- If `conditional_negate` does not negate, the output still represents the base element. -/
 private theorem conditional_negate_eq_of_not_negative
-    (base r1 x r2 : backend.serial.u64.field.FieldElement51)
+    (base r1 x r2 : field.FieldElement51)
     (r_is_negative : subtle.Choice)
     (h_not_neg : r_is_negative.val ≠ 1#u8)
     (r1_eq : Field51_as_Nat r1 = Field51_as_Nat base)
@@ -555,7 +556,7 @@ private theorem conditional_negate_eq_of_not_negative
 /-- Main algebraic bridge before the branch split in `sqrt_ratio_i`. -/
 private theorem check_eq_v_of_sqrt_ratio_data
     (u v fe v3 fe1 v7 fe2 fe3 fe4 r fe5 check :
-      backend.serial.u64.field.FieldElement51)
+      field.FieldElement51)
     (check_post1 :
       Field51_as_Nat check ≡ Field51_as_Nat v * Field51_as_Nat fe5 [MOD p])
     (fe5_post1 :
@@ -617,7 +618,7 @@ private theorem check_eq_v_of_sqrt_ratio_data
 /-- Main algebraic bridge before the branch split in `sqrt_ratio_i`. -/
 private theorem check_eq_mod_of_sqrt_ratio_data
     (u v fe v3 fe1 v7 fe2 fe3 fe4 r fe5 check r_prime :
-      backend.serial.u64.field.FieldElement51)
+      field.FieldElement51)
     (r_prime_post1 :
       Field51_as_Nat r_prime ≡
         Field51_as_Nat SQRT_M1_val * Field51_as_Nat r [MOD p])
@@ -716,7 +717,7 @@ private theorem modEq_zero_of_sqrt_m1_mul_self {a : ℕ}
 
 /-- Bundled postcondition for a fully normalized `sqrt_ratio_i` result. -/
 private abbrev sqrt_ratio_i_cases
-    (u v r2 : backend.serial.u64.field.FieldElement51)
+    (u v r2 : field.FieldElement51)
     (c : subtle.Choice) : Prop :=
   (Field51_as_Nat u % p = 0 →
       c.val = 1#u8 ∧ Field51_as_Nat r2 % p = 0 ∧
@@ -742,7 +743,7 @@ section sqrt_ratio_i_branch_solvers
 
 variable
   {u v fe v3 fe2 fe4 r fe5 check fe6 fe7 r_prime r1 r_neg r2 :
-    backend.serial.u64.field.FieldElement51}
+    field.FieldElement51}
   {r_is_negative : subtle.Choice}
 
 /-- Solves the branch where `check = -u`, so `r_prime` is the square root candidate. -/
@@ -1329,21 +1330,11 @@ end sqrt_ratio_i_branch_solvers
 
 attribute [local irreducible] p
 
-set_option maxHeartbeats 400000 in -- the proof works even with 230k heartbeats, but not much less.
-/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::sqrt_ratio_i`**
-(auxiliary existential form, used internally to derive `sqrt_ratio_i_spec`).
-• The function succeeds (no panic) for limb-bounded inputs `u, v` with limbs `< 2^54`
-• If `u ≡ 0 (mod p)`, then `c.1 = 1` and `r ≡ 0 (mod p)`
-• If `u ≢ 0` and `v ≡ 0 (mod p)`, then `c.1 = 0` and `r ≡ 0 (mod p)`
-• If `u ≢ 0`, `v ≢ 0`, and `u/v` is a square, then `c.1 = 1` and `r^2 * v ≡ u (mod p)`
-• If `u ≢ 0`, `v ≢ 0`, and `u/v` is not a square, then `c.1 = 0` and
-  `r^2 * v ≡ SQRT_M1 * u (mod p)`
-• The output limbs satisfy `c.2[i] ≤ 2^53 - 1`
-• The result `r` is non-negative (`r % p % 2 = 0`)
--/
+set_option maxHeartbeats 400000 in -- this proof even works with 230k heartbeats, but not much less.
+/-- Existential-form helper used internally to derive `sqrt_ratio_i_spec`. -/
 private theorem sqrt_ratio_i_spec'
-    (u : backend.serial.u64.field.FieldElement51)
-    (v : backend.serial.u64.field.FieldElement51)
+    (u : field.FieldElement51)
+    (v : field.FieldElement51)
     (h_u_bounds : ∀ i, i < 5 → (u[i]!).val < 2 ^ 54)
     (h_v_bounds : ∀ i, i < 5 → (v[i]!).val < 2 ^ 54) :
     ∃ c, sqrt_ratio_i u v = ok c ∧
@@ -1354,19 +1345,19 @@ private theorem sqrt_ratio_i_spec'
     -- Case 1: u is zero
     (u_nat = 0 →
     c.1.val = 1#u8 ∧ r_nat = 0 ∧
-    (∀ i < 5,  c.2[i]!.val ≤ 2 ^ 53 - 1)) ∧
+    (∀ i < 5, c.2[i]!.val ≤ 2 ^ 53 - 1)) ∧
     -- Case 2: u is nonzero and v is zero
     (u_nat ≠ 0 ∧ v_nat = 0 →
     c.1.val = 0#u8 ∧ r_nat = 0 ∧
-    (∀ i < 5,  c.2[i]!.val ≤ 2 ^ 53 - 1)) ∧
+    (∀ i < 5, c.2[i]!.val ≤ 2 ^ 53 - 1)) ∧
     -- Case 3: u and v are nonzero and u/v is a square
-    (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (∃ x : Nat, (x^2 * v_nat) % p = u_nat) →
+    (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (∃ x : Nat, (x ^ 2 * v_nat) % p = u_nat) →
     c.1.val = 1#u8 ∧ (r_nat ^ 2 * v_nat) % p = u_nat ∧
-    (∀ i < 5,  c.2[i]!.val ≤ 2 ^ 53 - 1)) ∧
+    (∀ i < 5, c.2[i]!.val ≤ 2 ^ 53 - 1)) ∧
     -- Case 4: u and v are nonzero and u/v is not a square
-    (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (¬(∃ x : Nat, (x^2 * v_nat) % p = u_nat)) →
-    c.1.val = 0#u8 ∧ (r_nat ^2 * v_nat) % p = (i_nat * u_nat) % p ∧
-    (∀ i < 5,  c.2[i]!.val ≤ 2 ^ 53 - 1)) ∧
+    (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (¬(∃ x : Nat, (x ^ 2 * v_nat) % p = u_nat)) →
+    c.1.val = 0#u8 ∧ (r_nat ^ 2 * v_nat) % p = (i_nat * u_nat) % p ∧
+    (∀ i < 5, c.2[i]!.val ≤ 2 ^ 53 - 1)) ∧
     -- Non-negativity of the result
     (r_nat % 2 = 0)
     := by
@@ -1412,8 +1403,8 @@ private theorem sqrt_ratio_i_spec'
       r_prime_post1 check_post1 fe5_post1 r_post1 fe4_post1 fe3_post1 fe2_post1
       v7_post1 fe1_post1 v3_post1 fe_post1
   have u_m := nat_sqrt_m1_sq_of_add_modeq_zero fe6_post1
-  have check_eq_r_v:= check_post1.trans (fe5_post1.mul_left (Field51_as_Nat v))
-  rw[mul_comm] at check_eq_r_v
+  have check_eq_r_v := check_post1.trans (fe5_post1.mul_left (Field51_as_Nat v))
+  rw [mul_comm] at check_eq_r_v
   by_cases first_choice :  flipped_sign_sqrt.val = 1#u8
   · simp only [show flipped_sign_sqrt.val = 1#u8 ∨ flipped_sign_sqrt_i.val = 1#u8 from
         Or.inl first_choice, show correct_sign_sqrt.val = 1#u8 ∨ flipped_sign_sqrt.val = 1#u8 from
@@ -1560,25 +1551,25 @@ private theorem sqrt_ratio_i_spec'
 -/
 @[step]
 theorem sqrt_ratio_i_spec
-    (u : backend.serial.u64.field.FieldElement51)
-    (v : backend.serial.u64.field.FieldElement51)
+    (u : field.FieldElement51)
+    (v : field.FieldElement51)
     (h_u_bounds : ∀ i, i < 5 → (u[i]!).val < 2 ^ 54)
     (h_v_bounds : ∀ i, i < 5 → (v[i]!).val < 2 ^ 54) :
-    sqrt_ratio_i u v ⦃ (c : subtle.Choice × backend.serial.u64.field.FieldElement51) =>
+    sqrt_ratio_i u v ⦃ (result : subtle.Choice × field.FieldElement51) =>
       let u_nat := Field51_as_Nat u % p
       let v_nat := Field51_as_Nat v % p
-      let r_nat := Field51_as_Nat c.2 % p
+      let r_nat := Field51_as_Nat result.2 % p
       let i_nat := Field51_as_Nat SQRT_M1_val % p
-      (∀ i < 5,  c.2[i]!.val ≤ 2 ^ 53 - 1) ∧
+      (∀ i < 5, result.2[i]!.val ≤ 2 ^ 53 - 1) ∧
       (r_nat % 2 = 0) ∧
       (u_nat = 0 →
-        c.1.val = 1#u8 ∧ r_nat = 0) ∧
+        result.1.val = 1#u8 ∧ r_nat = 0) ∧
       (u_nat ≠ 0 ∧ v_nat = 0 →
-        c.1.val = 0#u8 ∧ r_nat = 0) ∧
-      (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (∃ x : Nat, (x^2 * v_nat) % p = u_nat) →
-        c.1.val = 1#u8 ∧ (r_nat ^ 2 * v_nat) % p = u_nat) ∧
-      (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (¬(∃ x : Nat, (x^2 * v_nat) % p = u_nat)) →
-        c.1.val = 0#u8 ∧ (r_nat ^2 * v_nat) % p = (i_nat * u_nat) % p) ⦄ := by
+        result.1.val = 0#u8 ∧ r_nat = 0) ∧
+      (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (∃ x : Nat, (x ^ 2 * v_nat) % p = u_nat) →
+        result.1.val = 1#u8 ∧ (r_nat ^ 2 * v_nat) % p = u_nat) ∧
+      (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (¬(∃ x : Nat, (x ^ 2 * v_nat) % p = u_nat)) →
+        result.1.val = 0#u8 ∧ (r_nat ^ 2 * v_nat) % p = (i_nat * u_nat) % p) ⦄ := by
   have ⟨c, h_ok, h1, h2, h3, h4, h_nonneg⟩ := sqrt_ratio_i_spec' u v h_u_bounds h_v_bounds
   exact exists_imp_spec ⟨c, h_ok, by
     refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩

--- a/functions.json
+++ b/functions.json
@@ -6943,10 +6943,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem invert_spec (r : backend.serial.u64.field.FieldElement51)\n    (h_bounds : ∀ i, i < 5 → (r[i]!).val < 2 ^ 54) :\n    invert r ⦃ (r' : backend.serial.u64.field.FieldElement51) =>\n      let r_nat := Field51_as_Nat r % p\n      let r'_nat := Field51_as_Nat r' % p\n      (r_nat ≠ 0 → (r'_nat * r_nat) % p = 1) ∧\n      (r_nat = 0 → r'_nat = 0) ∧\n      (∀ i, i < 5 → (r'[i]!).val < 2 ^ 52) ⦄ := by ...",
+   "theorem invert_spec (r : backend.serial.u64.field.FieldElement51)\n    (h_bounds : ∀ i, i < 5 → (r[i]!).val < 2 ^ 54) :\n    invert r ⦃ (r' : backend.serial.u64.field.FieldElement51) =>\n      (Field51_as_Nat r % p ≠ 0 →\n        (Field51_as_Nat r' % p * (Field51_as_Nat r % p)) % p = 1) ∧\n      (Field51_as_Nat r % p = 0 → Field51_as_Nat r' % p = 0) ∧\n      (∀ i, i < 5 → (r'[i]!).val < 2 ^ 52) ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Field/FieldElement51/Invert.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `field.FieldElement51.invert`**:\n- No panic for field element inputs r (always returns r' successfully)\n- If r ≢ 0 (mod p), then Field51_as_Nat(r') * Field51_as_Nat(r) ≡ 1 (mod p)\n- If r ≡ 0 (mod p), then Field51_as_Nat(r') ≡ 0 (mod p)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::invert`**\n• No panic when each input limb of r satisfies `r[i].val < 2 ^ 54`\n  (always returns r' successfully)\n• If r ≢ 0 (mod p), then Field51_as_Nat(r') * Field51_as_Nat(r) ≡ 1 (mod p)\n• If r ≡ 0 (mod p), then Field51_as_Nat(r') ≡ 0 (mod p)\n• The output limbs satisfy `r'[i].val < 2^52` for all `i < 5`\n-/",
    "source": "curve25519-dalek/src/field.rs",
    "rust_name":
    "curve25519_dalek::field::{curve25519_dalek::backend::serial::u64::field::FieldElement51}::invert",
@@ -6966,10 +6966,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem invsqrt_spec\n    (v : backend.serial.u64.field.FieldElement51)\n    (h_v_bounds : ∀ i, i < 5 → (v[i]!).val ≤ 2 ^ 52 - 1) :\n    invsqrt v ⦃ res =>\n    let v_nat := Field51_as_Nat v % p\n    let r_nat := Field51_as_Nat res.snd % p\n    let i_nat := Field51_as_Nat SQRT_M1_val % p\n    -- Unconditional bounds\n    (∀ i < 5, res.snd[i]!.val ≤ 2 ^ 53 - 1) ∧\n    -- Non-negativity\n    (r_nat % 2 = 0) ∧\n    -- Case 1: If v ≡ 0 (mod p), then c.val = 0 and r ≡ 0 (mod p)\n    (v_nat = 0 → res.fst.val = 0#u8 ∧ r_nat = 0) ∧\n    -- Case 2: If v ≢ 0 and ∃ x, x^2 * v ≡ 1 (mod p), then c.val = 1 and r^2 * v ≡ 1 (mod p)\n    (v_nat ≠ 0 ∧ (∃ x : Nat, (x ^ 2 * v_nat) % p = 1) →\n      res.fst.val = 1#u8 ∧ (r_nat ^ 2 * v_nat) % p = 1) ∧\n    -- Case 3: If v ≢ 0 and ¬∃ x, x^2 * v ≡ 1 (mod p), then c.val = 0 and r^2 * v ≡ i (mod p)\n    (v_nat ≠ 0 ∧ ¬(∃ x : Nat, (x ^ 2 * v_nat) % p = 1) →\n      res.fst.val = 0#u8 ∧ (r_nat ^ 2 * v_nat) % p = i_nat) ⦄ := by ...",
+   "theorem invsqrt_spec\n    (v : backend.serial.u64.field.FieldElement51)\n    (h_v_bounds : ∀ i, i < 5 → (v[i]!).val ≤ 2 ^ 52 - 1) :\n    invsqrt v ⦃ (result : subtle.Choice × backend.serial.u64.field.FieldElement51) =>\n      let v_nat := Field51_as_Nat v % p\n      let r_nat := Field51_as_Nat result.snd % p\n      let i_nat := Field51_as_Nat SQRT_M1_val % p\n      -- Output limb bounds\n      (∀ i < 5, result.snd[i]!.val ≤ 2 ^ 53 - 1) ∧\n      -- Non-negativity\n      (r_nat % 2 = 0) ∧\n      -- Case 1: If v ≡ 0 (mod p), then c.val = 0 and r ≡ 0 (mod p)\n      (v_nat = 0 → result.fst.val = 0#u8 ∧ r_nat = 0) ∧\n      -- Case 2: If v ≢ 0 and ∃ x, x^2 * v ≡ 1 (mod p), then c.val = 1 and r^2 * v ≡ 1 (mod p)\n      (v_nat ≠ 0 ∧ (∃ x : Nat, (x ^ 2 * v_nat) % p = 1) →\n        result.fst.val = 1#u8 ∧ (r_nat ^ 2 * v_nat) % p = 1) ∧\n      -- Case 3: If v ≢ 0 and ¬∃ x, x^2 * v ≡ 1 (mod p), then c.val = 0 and r^2 * v ≡ i (mod p)\n      (v_nat ≠ 0 ∧ ¬(∃ x : Nat, (x ^ 2 * v_nat) % p = 1) →\n        result.fst.val = 0#u8 ∧ (r_nat ^ 2 * v_nat) % p = i_nat) ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Field/FieldElement51/InvSqrt.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `field.FieldElement51.invsqrt`**:\n- No panic for field element inputs v (always returns (c, r) successfully)\n- Output limbs bounded by 2^53 - 1\n- Result r is non-negative (r_nat % 2 = 0)\n- The result satisfies exactly one of three mutually exclusive cases:\n  1. If v ≡ 0 (mod p), then c.val = 0 and r ≡ 0 (mod p)\n  2. If v ≢ 0 and ∃ x, x^2 * v ≡ 1 (mod p), then c.val = 1 and r^2 * v ≡ 1 (mod p)\n  3. If v ≢ 0 and ¬∃ x, x^2 * v ≡ 1 (mod p), then c.val = 0 and r^2 * v ≡ SQRT_M1 (mod p)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::invsqrt`**\n• The function succeeds (no panic) for field element inputs `v` with limbs bounded by `2^52 - 1`\n• Output limbs are bounded by `2^53 - 1`\n• The result `r` is non-negative (`r_nat % 2 = 0`)\n• If `v ≡ 0 (mod p)`, then `c.val = 0` and `r ≡ 0 (mod p)`\n• If `v ≢ 0 (mod p)` and `v` is a square, then `c.val = 1` and `r^2 * v ≡ 1 (mod p)`\n• If `v ≢ 0 (mod p)` and `v` is not a square, then `c.val = 0` and `r^2 * v ≡ i (mod p)`\n-/",
    "source": "curve25519-dalek/src/field.rs",
    "rust_name":
    "curve25519_dalek::field::{curve25519_dalek::backend::serial::u64::field::FieldElement51}::invsqrt",
@@ -6988,9 +6988,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem is_negative_spec (r : backend.serial.u64.field.FieldElement51) :\n    is_negative r ⦃ c =>\n    (c.val = 1#u8 ↔ (Field51_as_Nat r % p) % 2 = 1) ⦄ := by ...",
+   "theorem is_negative_spec (self : backend.serial.u64.field.FieldElement51) :\n    is_negative self ⦃ (c : subtle.Choice) =>\n      (c.val = 1#u8 ↔ (Field51_as_Nat self % p) % 2 = 1) ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Field/FieldElement51/IsNegative.lean",
-   "spec_docstring": null,
+   "spec_docstring":
+   "/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::is_negative`**\n• The function always succeeds (no panic).\n• The result `c` satisfies `c.val = 1` iff the canonical representative of the\n  field element modulo `p = 2^255 - 19` is odd.\n-/",
    "source": "curve25519-dalek/src/field.rs",
    "rust_name":
    "curve25519_dalek::field::{curve25519_dalek::backend::serial::u64::field::FieldElement51}::is_negative",
@@ -7008,9 +7009,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem is_zero_spec (r : backend.serial.u64.field.FieldElement51) :\n    is_zero r ⦃ c =>\n    (c.val = 1#u8 ↔ Field51_as_Nat r % p = 0) ⦄ := by ...",
+   "theorem is_zero_spec (self : backend.serial.u64.field.FieldElement51) :\n    is_zero self ⦃ (c : subtle.Choice) =>\n      (c.val = 1#u8 ↔ Field51_as_Nat self % p = 0) ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Field/FieldElement51/IsZero.lean",
-   "spec_docstring": null,
+   "spec_docstring":
+   "/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::is_zero`**\n• The function always succeeds (no panic).\n• The result `c` satisfies `c.val = 1#u8` iff the canonical representative of\n  the field element modulo `p = 2^255 - 19` equals zero.\n-/",
    "source": "curve25519-dalek/src/field.rs",
    "rust_name":
    "curve25519_dalek::field::{curve25519_dalek::backend::serial::u64::field::FieldElement51}::is_zero",
@@ -7028,10 +7030,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem pow22501_spec (r : backend.serial.u64.field.FieldElement51)\n    (h_bounds : ∀ i, i < 5 → (r[i]!).val < 2 ^ 54) :\n    pow22501 r ⦃ result =>\n    let r1 := result.1\n    let r2 := result.2\n    Field51_as_Nat r1 % p = (Field51_as_Nat r ^ (2 ^ 250 - 1)) % p ∧\n    Field51_as_Nat r2 % p = (Field51_as_Nat r ^ 11) % p ∧\n    (∀ i, i < 5 → (r1[i]!).val < 2 ^ 52) ∧\n    (∀ i, i < 5 → (r2[i]!).val < 2 ^ 52) ⦄ := by ...",
+   "theorem pow22501_spec (self : backend.serial.u64.field.FieldElement51)\n    (h_bounds : ∀ i, i < 5 → (self[i]!).val < 2 ^ 54) :\n    pow22501 self ⦃ (result : backend.serial.u64.field.FieldElement51 ×\n        backend.serial.u64.field.FieldElement51) =>\n      let r1 := result.1\n      let r2 := result.2\n      Field51_as_Nat r1 % p = (Field51_as_Nat self ^ (2 ^ 250 - 1)) % p ∧\n      Field51_as_Nat r2 % p = (Field51_as_Nat self ^ 11) % p ∧\n      (∀ i, i < 5 → (r1[i]!).val < 2 ^ 52) ∧\n      (∀ i, i < 5 → (r2[i]!).val < 2 ^ 52) ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Field/FieldElement51/Pow22501.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `field.FieldElement51.pow22501`**:\n- No panic (always returns (r1, r2) successfully)\n- Field51_as_Nat(r1) ≡ Field51_as_Nat(r)^(2^250-1) (mod p)\n  Field51_as_Nat(r2) ≡ Field51_as_Nat(r)^11 (mod p)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::pow22501`**\n• No panic (always returns (r1, r2) successfully)\n• Field51_as_Nat(r1) ≡ Field51_as_Nat(self)^(2^250-1) (mod p)\n• Field51_as_Nat(r2) ≡ Field51_as_Nat(self)^11 (mod p)\n• Each limb of r1 is bounded by 2^52\n• Each limb of r2 is bounded by 2^52\n-/",
    "source": "curve25519-dalek/src/field.rs",
    "rust_name":
    "curve25519_dalek::field::{curve25519_dalek::backend::serial::u64::field::FieldElement51}::pow22501",
@@ -7054,7 +7056,7 @@
    "theorem pow_p58_spec (self : FieldElement51) (h_bounds : ∀ i, i < 5 → (self[i]!).val ≤ 2 ^ 52 - 1) :\n    pow_p58 self ⦃ (result : FieldElement51) =>\n      Field51_as_Nat result % p = (Field51_as_Nat self ^ pow_p58_exp) % p ∧\n      (∀ i < 5, result[i]!.val < 2 ^ 52) ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Field/FieldElement51/PowP58.lean",
    "spec_docstring":
-   "/-- **Spec theroem for `field.FieldElement51.pow_p58`**:\n- Field51_as_Nat(result) ≡ Field51_as_Nat(self)^(2^252-3) (mod p)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::pow_p58`**\n• The function never panics, given that each limb of `self` is bounded by `2^52 - 1`\n• `Field51_as_Nat(result) ≡ Field51_as_Nat(self) ^ (2^252 - 3) (mod p)`\n• Each limb of the result is bounded by `2^52`\n-/",
    "source": "curve25519-dalek/src/field.rs",
    "rust_name":
    "curve25519_dalek::field::{curve25519_dalek::backend::serial::u64::field::FieldElement51}::pow_p58",
@@ -7074,9 +7076,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem sqrt_ratio_i_spec\n    (u : backend.serial.u64.field.FieldElement51)\n    (v : backend.serial.u64.field.FieldElement51)\n    (h_u_bounds : ∀ i, i < 5 → (u[i]!).val < 2 ^ 54)\n    (h_v_bounds : ∀ i, i < 5 → (v[i]!).val < 2 ^ 54) :\n    sqrt_ratio_i u v ⦃ c =>\n    let u_nat := Field51_as_Nat u % p\n    let v_nat := Field51_as_Nat v % p\n    let r_nat := Field51_as_Nat c.2 % p\n    let i_nat := Field51_as_Nat SQRT_M1_val % p\n    (∀ i < 5,  c.2[i]!.val ≤ 2 ^ 53 - 1) ∧\n    (r_nat % 2 = 0) ∧\n    (u_nat = 0 →\n      c.1.val = 1#u8 ∧ r_nat = 0) ∧\n    (u_nat ≠ 0 ∧ v_nat = 0 →\n      c.1.val = 0#u8 ∧ r_nat = 0) ∧\n    (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (∃ x : Nat, (x^2 * v_nat) % p = u_nat) →\n      c.1.val = 1#u8 ∧ (r_nat ^ 2 * v_nat) % p = u_nat) ∧\n    (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (¬(∃ x : Nat, (x^2 * v_nat) % p = u_nat)) →\n      c.1.val = 0#u8 ∧ (r_nat ^2 * v_nat) % p = (i_nat * u_nat) % p)\n    ⦄ := by ...",
+   "theorem sqrt_ratio_i_spec\n    (u : field.FieldElement51)\n    (v : field.FieldElement51)\n    (h_u_bounds : ∀ i, i < 5 → (u[i]!).val < 2 ^ 54)\n    (h_v_bounds : ∀ i, i < 5 → (v[i]!).val < 2 ^ 54) :\n    sqrt_ratio_i u v ⦃ (result : subtle.Choice × field.FieldElement51) =>\n      let u_nat := Field51_as_Nat u % p\n      let v_nat := Field51_as_Nat v % p\n      let r_nat := Field51_as_Nat result.2 % p\n      let i_nat := Field51_as_Nat SQRT_M1_val % p\n      (∀ i < 5, result.2[i]!.val ≤ 2 ^ 53 - 1) ∧\n      (r_nat % 2 = 0) ∧\n      (u_nat = 0 →\n        result.1.val = 1#u8 ∧ r_nat = 0) ∧\n      (u_nat ≠ 0 ∧ v_nat = 0 →\n        result.1.val = 0#u8 ∧ r_nat = 0) ∧\n      (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (∃ x : Nat, (x ^ 2 * v_nat) % p = u_nat) →\n        result.1.val = 1#u8 ∧ (r_nat ^ 2 * v_nat) % p = u_nat) ∧\n      (u_nat ≠ 0 ∧ v_nat ≠ 0 ∧ (¬(∃ x : Nat, (x ^ 2 * v_nat) % p = u_nat)) →\n        result.1.val = 0#u8 ∧ (r_nat ^ 2 * v_nat) % p = (i_nat * u_nat) % p) ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Field/FieldElement51/SqrtRatioi.lean",
-   "spec_docstring": null,
+   "spec_docstring":
+   "/-- **Spec theorem for `curve25519_dalek::field::FieldElement51::sqrt_ratio_i`**\n• The function succeeds (no panic) for limb-bounded inputs `u, v` with limbs `< 2^54`\n• Output limbs are bounded by `2^53 - 1`\n• The result `r` is non-negative (`r_nat % 2 = 0`)\n• If `u ≡ 0 (mod p)`, then `c.1 = 1` and `r ≡ 0 (mod p)`\n• If `u ≢ 0` and `v ≡ 0 (mod p)`, then `c.1 = 0` and `r ≡ 0 (mod p)`\n• If `u ≢ 0`, `v ≢ 0`, and `u/v` is a square, then `c.1 = 1` and `r^2 * v ≡ u (mod p)`\n• If `u ≢ 0`, `v ≢ 0`, and `u/v` is not a square, then `c.1 = 0` and\n  `r^2 * v ≡ SQRT_M1 * u (mod p)`\n-/",
    "source": "curve25519-dalek/src/field.rs",
    "rust_name":
    "curve25519_dalek::field::{curve25519_dalek::backend::serial::u64::field::FieldElement51}::sqrt_ratio_i",


### PR DESCRIPTION
This PR systematically streamlines the style, formatting, and code of all 7 spec theorem files in:

- Specs/Field

This PR fixes many small issues, establishing a consistent and clean style.

Frequently made improvements include:

- Adding explicit type annotations to Aeneas result binders: ⦃ result => → ⦃ (result : SomeType) =>
- Name shortenings via removal of redundant prefixes (Std.U8 → U8, scalar.Scalar → Scalar)
- Combining open statements (open A + open B → open A B)
- Merging mathematical information in "natural language description / natural language specs" into module and theorem docstrings
- General docstring improvements
- ...

Closes #777