### PR TITLE
style: streamline all files in Edwards/Affine and Edwards/CompressedEdwardsY

### DIFF
--- a/Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/Compress.lean
+++ b/Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/Compress.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
@@ -11,51 +11,34 @@ import Curve25519Dalek.Aux
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ToBytes
 import Curve25519Dalek.Specs.Field.FieldElement51.IsNegative
 
-/-! # Spec Theorem for `AffinePoint::compress`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::compress`
 
-Specification and proof for `edwards.affine.AffinePoint.compress`.
+Converts an Edwards affine point `(x, y)` into its 32-byte
+`CompressedEdwardsY` representation:
 
-This function converts an Edwards affine point (x, y) into its 32-byte
-CompressedEdwardsY representation by serializing y in little-endian and
-storing the sign bit of x in the most significant bit of the last byte.
+- Takes an affine Edwards point with coordinates `(x, y)`
+- Serializes `y` to a 32-byte little-endian array
+- Computes the sign (parity) bit of `x` as a `subtle::Choice`
+- Sets the MSB (bit 7) of byte 31 of the serialized `y` to this sign bit (via XOR)
+- Returns the resulting 32-byte array as `CompressedEdwardsY`
 
-**Source**: curve25519-dalek/src/edwards/affine.rs
-
-## TODO
-- Complete proof
+Source: "curve25519-dalek/src/edwards/affine.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-open curve25519_dalek.math
-open curve25519_dalek.backend.serial.u64.field.FieldElement51
+open curve25519_dalek.math curve25519_dalek.backend.serial.u64.field.FieldElement51
 namespace curve25519_dalek.edwards.affine.AffinePoint
 
-/-
-Natural language description:
-
-    * Takes an affine Edwards point with coordinates (x, y)
-    * Serializes y to a 32-byte little-endian array
-    * Computes the sign (parity) bit of x as a subtle.Choice
-    * Sets the MSB (bit 7) of byte 31 of the serialized y to this sign bit (via XOR)
-    * Returns the resulting 32-byte array as CompressedEdwardsY
-
-Natural language specs:
-
-    * The function always succeeds (no panic) when the AffinePoint is valid
-    * On success, the byte encoding equals compress_edwards_pure(self.toPoint),
-      i.e. the canonical y-coordinate in the lower 255 bits with the x parity
-      in bit 255
--/
-
-
-/-- **Spec and proof concerning `edwards.affine.AffinePoint.compress`**:
-- Requires: the AffinePoint is valid (limbs < 2^54, on curve)
-- Ensures: the compressed bytes equal the pure mathematical compression of the point
+/-- **Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::compress`**
+• The function always succeeds (no panic) when the `AffinePoint` is valid
+• The encoded byte array represents the canonical y-coordinate of `self` in
+  its lower 255 bits, with the parity (sign) bit of x stored in bit 255
 -/
 @[step]
 theorem compress_spec (self : AffinePoint) (hself : self.IsValid) :
-    compress self ⦃ result =>
-    U8x32_as_Nat result = compress_edwards_pure (self.toPoint) ⦄ := by
+    compress self ⦃ (result : edwards.CompressedEdwardsY) =>
+      U8x32_as_Nat result = compress_edwards_pure (self.toPoint) ⦄ := by
   unfold compress
   -- Chain to_bytes_spec (y → canonical bytes) and is_negative_spec (x → sign)
   let* ⟨s, h_mod, h_lt⟩ ← to_bytes_spec

--- a/Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/ConditionalSelect.lean
+++ b/Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/ConditionalSelect.lean
@@ -1,51 +1,30 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ConditionalSelect
 
-/-! # Spec Theorem for `AffinePoint::conditional_select`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::conditional_select`
 
-Specification and proof for the `ConditionallySelectable` trait implementation for `AffinePoint`.
-
-This function conditionally selects between two affine Edwards points based on a `Choice` value
+This function performs a constant-time conditional selection between two affine Edwards points
 by applying `FieldElement51::conditional_select` component-wise to the coordinates (x, y).
 
-Returns `b` when `choice = 1` and `a` when `choice = 0`, in constant time.
-
-**Source**: curve25519-dalek/src/edwards/affine.rs
+Source: "curve25519-dalek/src/edwards/affine.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.edwards.affine.AffinePoint.Insts.SubtleConditionallySelectable
 
-/-
-natural language description:
-
-- Takes two AffinePoints `a` and `b` and a `Choice` value
-- Returns one of the two points based on the choice, in constant time
-- Implementation: applies `FieldElement51::conditional_select` component-wise
-  to the coordinates (x, y)
-
-natural language specs:
-
-- The function always succeeds (no panic)
-- Returns `b` when `choice = 1` and `a` when `choice = 0`
--/
-
-/--
-**Spec and proof** concerning:
-`edwards.affine.AffinePoint.Insts.SubtleConditionallySelectable.conditional_select`:
-- No panic (always returns successfully)
-- Returns `b` when `choice = 1` and `a` when `choice = 0`
+/-- **Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::conditional_select`**
+• No panic (always returns successfully)
+• Returns `b` when `choice = 1` and `a` when `choice = 0`
 -/
 @[step]
-theorem conditional_select_spec
-    (a b : edwards.affine.AffinePoint)
-    (choice : subtle.Choice) :
-    conditional_select a b choice ⦃ (result : edwards.affine.AffinePoint) =>
+theorem conditional_select_spec (a b : AffinePoint) (choice : subtle.Choice) :
+    conditional_select a b choice ⦃ (result : AffinePoint) =>
       result = if choice.val = 1#u8 then b else a ⦄ := by
   unfold conditional_select
   step as ⟨feX, hfeX⟩
@@ -62,7 +41,7 @@ theorem conditional_select_spec
   all_goals simp only [h, ite_true, ite_false] at *
   all_goals obtain ⟨_, _⟩ := a
   all_goals obtain ⟨_, _⟩ := b
-  all_goals simp only [edwards.affine.AffinePoint.mk.injEq] at *
+  all_goals simp only [AffinePoint.mk.injEq] at *
   all_goals exact ⟨arr_ext _ _ hfeX, arr_ext _ _ hfeY⟩
 
 end curve25519_dalek.edwards.affine.AffinePoint.Insts.SubtleConditionallySelectable

--- a/Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/CtEq.lean
+++ b/Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/CtEq.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
@@ -10,58 +10,43 @@ import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Math.Montgomery.Curve
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.CtEq
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ToBytes
-
 import Mathlib.Data.Nat.ModEq
 
-/-! # Spec Theorem for `AffinePoint::ct_eq`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::ct_eq`
 
-Specification and proof for `AffinePoint::ct_eq`.
+Performs constant-time equality comparison for affine Edwards points:
 
-This function performs constant-time equality comparison for affine Edwards points.
+• Compares two `AffinePoint`s to determine whether they represent the same point.
+• Checks equality of coordinates `(x, y)` by comparing the canonical byte encodings
+  of each coordinate via `FieldElement51::ct_eq`.
+• The results for `x` and `y` are combined with a bitwise AND on `Choice` values.
+• Runs in constant time irrespective of the inputs to avoid timing-based security
+  liabilities.
+
 Unlike `EdwardsPoint::ct_eq`, which must cross-multiply by Z coordinates, affine points
-store (x, y) directly, so equality reduces to coordinate-wise comparison via
-`FieldElement51::ct_eq` on x and y, combined with a bitwise AND.
+store `(x, y)` directly, so equality reduces to coordinate-wise comparison.
 
-**Source**: curve25519-dalek/src/edwards/affine.rs
+Source: "curve25519-dalek/src/edwards/affine.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.u64.field.FieldElement51
-
 namespace curve25519_dalek.edwards.affine.AffinePoint.Insts.SubtleConstantTimeEq
 
-/-
-Natural language description:
-
-    • Compares two AffinePoint types to determine whether they represent the same point
-
-    • Checks equality of coordinates (x, y) by comparing the canonical byte encodings
-      of each coordinate via FieldElement51::ct_eq
-
-    • The results for x and y are combined with a bitwise AND on Choice values
-
-    • Crucially does so in constant time irrespective of the inputs to avoid security liabilities
-
-Natural language specs:
-
-    • The operation never panics (always returns successfully)
-    • Returns Choice.one (true) if and only if x₁ ≡ x₂ (mod p) and y₁ ≡ y₂ (mod p)
-    • When both points are valid, this is equivalent to toPoint equality
--/
-
-/-- **Spec and proof** concerning:
-`edwards.affine.AffinePoint.Insts.SubtleConstantTimeEq.ct_eq`:
-- No panic (always returns successfully)
-- The result is Choice.one (true) if and only if the two points are equal (mod p) in coordinates
-- When both points are valid, this is equivalent to toPoint equality
+/-- **Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::ct_eq`**
+• The operation never panics (always returns successfully)
+• Returns `Choice.one` iff `self.x ≡ other.x (mod p)` and `self.y ≡ other.y (mod p)`
+• When both points are valid, this is equivalent to `toPoint` equality
 -/
 @[step]
 theorem ct_eq_spec (self other : AffinePoint) :
-  ct_eq self other ⦃ c =>
-  (c = Choice.one ↔
-    (Field51_as_Nat self.x) ≡ (Field51_as_Nat other.x) [MOD p] ∧
-    (Field51_as_Nat self.y) ≡ (Field51_as_Nat other.y) [MOD p]) ∧
-  (self.IsValid → other.IsValid → (c = Choice.one ↔ self.toPoint = other.toPoint)) ⦄ := by
+    ct_eq self other ⦃ (c : subtle.Choice) =>
+      (c = Choice.one ↔
+        (Field51_as_Nat self.x) ≡ (Field51_as_Nat other.x) [MOD p] ∧
+        (Field51_as_Nat self.y) ≡ (Field51_as_Nat other.y) [MOD p]) ∧
+      (self.IsValid → other.IsValid →
+        (c = Choice.one ↔ self.toPoint = other.toPoint)) ⦄ := by
   unfold ct_eq
   step as ⟨_, hcx⟩
   step as ⟨_, hcy⟩
@@ -89,7 +74,8 @@ theorem ct_eq_spec (self other : AffinePoint) :
       have h_nat_eq : U8x32_as_Nat ab = U8x32_as_Nat bb := by
         rw [h_a_canon, h_b_canon]; exact h_mod_eq
       apply U8x32_as_Nat_injective; exact h_nat_eq
-  rw [hc, hcx, hcy, to_bytes_iff_mod, to_bytes_iff_mod]; dsimp only [Nat.ModEq] at *
+  rw [hc, hcx, hcy, to_bytes_iff_mod, to_bytes_iff_mod]
+  dsimp only [Nat.ModEq] at *
   refine ⟨Iff.rfl, fun hv1 hv2 => ?_⟩
   -- Bridge: modular coordinate equalities ↔ toPoint equality
   have mod_iff_toPoint :

--- a/Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/Eq.lean
+++ b/Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/Eq.lean
@@ -1,71 +1,46 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Edwards.Affine.AffinePoint.CtEq
-/-! # Spec Theorem for `AffinePoint::eq`
 
-Specification and proof for the `eq` (PartialEq) trait implementation for affine Edwards points.
+/-!
+# Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::eq`
 
-This function performs equality comparison for two affine Edwards points by delegating
-to constant-time equality (`ct_eq`) and converting the resulting `Choice` to `Bool`.
+Equality comparison for two affine Edwards points.
+
+• Takes two `AffinePoint`s `self` and `other`.
+• Returns `true` if they represent the same point, `false` otherwise.
+• Implementation: delegates to `ct_eq` (constant-time equality), which compares
+  the x- and y-coordinates element-wise, then converts the resulting `Choice` to `Bool`.
+
 Two affine Edwards points (x₁, y₁) and (x₂, y₂) are considered equal when their
 coordinates are equal modulo p, i.e., x₁ ≡ x₂ (mod p) and y₁ ≡ y₂ (mod p).
 
-**Source**: curve25519-dalek/src/edwards/affine.rs
+Source: "curve25519-dalek/src/edwards/affine.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.u64.field
 namespace curve25519_dalek.edwards.affine.AffinePoint.Insts.CoreCmpPartialEqAffinePoint
 
-
-
-/-- If `c.val = 1`, then `c = Choice.one` (by proof irrelevance on the `valid` field). -/
-@[simp]
-theorem Choice.eq_one (c : subtle.Choice) : c.val = 1#u8 → c = Choice.one := by
-  intro h; cases c; simp_all [Choice.one]
-
-/-- If `c.val = 0`, then `c = Choice.zero` (by proof irrelevance on the `valid` field). -/
-@[simp]
-theorem Choice.eq_zero (c : subtle.Choice) : c.val = 0#u8 → c = Choice.zero := by
-  intro h; cases c; simp_all [Choice.zero]
-/-
-natural language description:
-
-• Takes two AffinePoints `self` and `other`
-• Returns `true` if they represent the same point, `false` otherwise
-• Implementation: delegates to `ct_eq` (constant-time equality) which compares
-  the x-coordinates and y-coordinates element-wise, then converts the `Choice` to `Bool`
-
-natural language specs:
-
+/-- **Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::eq`**
 • The function always succeeds (no panic) for valid input affine Edwards points
-• The result is `true` if and only if the two points represent the same point on the curve
--/
-
-/-- **Spec and proof concerning `edwards.affine.PartialEqAffinePoint.eq`**:
-• The function always succeeds (no panic) for valid inputs
 • The result is `true` if and only if the two points represent the same point on the curve
 -/
 @[step]
 theorem eq_spec (self other : AffinePoint) (h_self_valid : self.IsValid)
     (h_other_valid : other.IsValid) :
-    eq self other ⦃ result =>
-    result = true ↔ self.toPoint = other.toPoint ⦄ := by
+    eq self other ⦃ (result : Bool) =>
+      result = true ↔ self.toPoint = other.toPoint ⦄ := by
   unfold eq
   step*
   · unfold Bool.Insts.CoreConvertFromChoice.from
     simp only [spec_ok, decide_eq_true_eq]
-    have : c = Choice.one ↔ c.val = 1#u8 := by
-      constructor
-      · intro h
-        rw[h, Choice.one]
-      · apply Choice.eq_one
-    rw[← this]
+    rw [Choice.val_eq_one_iff]
     exact c_post2 h_self_valid h_other_valid
 
 end curve25519_dalek.edwards.affine.AffinePoint.Insts.CoreCmpPartialEqAffinePoint

--- a/Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/Identity.lean
+++ b/Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/Identity.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
@@ -9,41 +9,33 @@ import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ZERO
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ONE
 
+/-!
+# Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::identity`
 
-/-! # identity
+Returns the identity element of the Edwards curve in affine coordinates `(x, y) = (0, 1)`,
+i.e. the neutral element of the Ed25519 group law.
 
-Specification and proof for `AffinePoint::identity`.
-
-This function returns the identity element.
-
-**Source**: curve25519-dalek/src/edwards/affine.rs:L39-L44
+Source: "curve25519-dalek/src/edwards/affine.rs"
 -/
 
-open Aeneas Aeneas.Std Result Aeneas.Std.WP curve25519_dalek
-open backend.serial.u64.field.FieldElement51
+open Aeneas Aeneas.Std Result Aeneas.Std.WP
+open curve25519_dalek.backend.serial.u64.field.FieldElement51
 namespace curve25519_dalek.edwards.affine.AffinePoint.Insts.Curve25519_dalekTraitsIdentity
 
-/-
-natural language description:
-
-• Returns the identity element of the Edwards curve in affine coordinates (x, y)
-
-natural language specs:
-
+/-- **Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::identity`**
 • The function always succeeds (no panic)
-• The resulting AffinePoint is the identity element with coordinates (x=0, y=1)
--/
-
-/-- **Spec and proof** concerning:
-`edwards.affine.AffinePoint.Insts.Curve25519_dalekTraitsIdentity.identity`
-- No panic (always returns successfully)
-- The resulting AffinePoint is the identity element of the Ed25519 group
+• The x-coordinate of the result is `0`
+• The y-coordinate of the result is `1`
+• The resulting `AffinePoint` is valid
+• The result represents the identity element of the Ed25519 group
 -/
 @[step]
 theorem identity_spec :
     identity ⦃ (q : AffinePoint) =>
-      Field51_as_Nat q.x = 0 ∧ Field51_as_Nat q.y = 1 ∧
-      q.IsValid ∧ q.toPoint = 0 ⦄ := by
+      Field51_as_Nat q.x = 0 ∧
+      Field51_as_Nat q.y = 1 ∧
+      q.IsValid ∧
+      q.toPoint = 0 ⦄ := by
   unfold identity ZERO ONE
   step*
   have hx : Field51_as_Nat fe = 0 := by rw [fe_post2]; decide
@@ -56,7 +48,5 @@ theorem identity_spec :
   ext
   · simp [toField, hx]
   · simp [toField, hy]
-
-
 
 end curve25519_dalek.edwards.affine.AffinePoint.Insts.Curve25519_dalekTraitsIdentity

--- a/Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/ToEdwards.lean
+++ b/Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/ToEdwards.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
@@ -9,57 +9,49 @@ import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ONE
 
-/-! # Spec Theorem for `AffinePoint::to_edwards`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::to_edwards`
 
-Specification and proof for `edwards.affine.AffinePoint.to_edwards`.
+Converts an affine Edwards point with coordinates `(x, y)` to extended twisted Edwards
+coordinates `(X, Y, Z, T)` by setting
 
-This function converts an affine Edwards point (x, y) to extended twisted Edwards
-coordinates (X, Y, Z, T) = (x, y, 1, x·y), lifting from affine to projective representation.
+  `X = x`,  `Y = y`,  `Z = 1`,  `T = x · y (mod p)`,
 
-**Source**: curve25519-dalek/src/edwards/affine.rs, lines 60:4-67:5
+where `p = 2^255 - 19`. This lifts the affine representation of the point to the
+extended projective representation used internally by the Edwards group law.
 
+Source: "curve25519-dalek/src/edwards/affine.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-namespace curve25519_dalek.edwards.affine.AffinePoint
 open curve25519_dalek.backend.serial.u64.field
 open curve25519_dalek.backend.serial.u64.field.FieldElement51
 
-/-
-natural language description:
-
-    Converts an affine Edwards point with coordinates (x, y) to extended twisted
-    Edwards coordinates (X, Y, Z, T) by setting:
-      X = x, Y = y, Z = 1, T = x * y (mod p)
-    where p = 2^255 - 19.
-
-natural language specs:
-
-    When the input is a valid AffinePoint with limbs satisfying the tighter < 2^53 bound:
-      - Structurally, X = self.x and Y = self.y (direct Rust copies)
-      - The resulting EdwardsPoint is valid (IsValid)
-      - The conversion preserves the represented mathematical point:
-        result.toPoint = self.toPoint in `Point Ed25519`
--/
-
+/-- Local helper: weakened spec for `ONE` with `2^53` limb bounds, suitable for
+feeding into the `to_edwards` proof. -/
 @[step]
-private lemma ONE_bounds_spec :
-    ONE ⦃ result => Field51_as_Nat result = 1 ∧ ∀ i < 5, result[i]!.val < 2 ^ 53 ⦄ := by
+private theorem ONE_bounds_spec :
+    ONE ⦃ (result : FieldElement51) =>
+      Field51_as_Nat result = 1 ∧
+      ∀ i < 5, result[i]!.val < 2 ^ 53 ⦄ := by
   unfold ONE from_limbs
   simp only [spec_ok]
   decide
 
-/-- **Spec and proof concerning `edwards.affine.AffinePoint.to_edwards`**:
-- No panic when `self` is a valid AffinePoint and its limbs are < 2^53
-- Structural: `result.X = self.x` and `result.Y = self.y` (direct Rust copies)
-- The resulting EdwardsPoint is valid: `result.IsValid`
-- Math bridge: `result.toPoint = self.toPoint` (same curve point in `Point Ed25519`)
+namespace curve25519_dalek.edwards.affine.AffinePoint
+
+/-- **Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::to_edwards`**
+• No panic when `self` is a valid AffinePoint and its limbs are < 2^53
+• `result.X = self.x` (direct Rust copy of the affine `x` coordinate)
+• `result.Y = self.y` (direct Rust copy of the affine `y` coordinate)
+• The resulting EdwardsPoint is valid: `result.IsValid`
+• Math bridge: `result.toPoint = self.toPoint` (same curve point in `Point Ed25519`)
 -/
 @[step]
 theorem to_edwards_spec (self : AffinePoint) (hself : self.IsValid)
-  (hx53 : ∀ i < 5, self.x[i]!.val < 2 ^ 53)
-  (hy53 : ∀ i < 5, self.y[i]!.val < 2 ^ 53) :
-    to_edwards self ⦃ result =>
+    (hx53 : ∀ i < 5, self.x[i]!.val < 2 ^ 53)
+    (hy53 : ∀ i < 5, self.y[i]!.val < 2 ^ 53) :
+    to_edwards self ⦃ (result : EdwardsPoint) =>
       result.X = self.x ∧
       result.Y = self.y ∧
       result.IsValid ∧
@@ -70,9 +62,9 @@ theorem to_edwards_spec (self : AffinePoint) (hself : self.IsValid)
   step as ⟨T, hT_mod, hT_bounds⟩
   step as ⟨Z, hZ_val, hZ_bounds⟩
   have hZ_F : Z.toField = 1 := by
-    unfold FieldElement51.toField; rw [hZ_val]; exact Nat.cast_one
+    unfold toField; rw [hZ_val]; exact Nat.cast_one
   have hT_F : T.toField = self.x.toField * self.y.toField := by
-    unfold FieldElement51.toField
+    unfold toField
     have h := Edwards.lift_mod_eq _ _ hT_mod
     push_cast at h; exact h
   have hres_valid : ({ X := self.x, Y := self.y, Z := Z, T := T } : EdwardsPoint).IsValid := {
@@ -86,7 +78,7 @@ theorem to_edwards_spec (self : AffinePoint) (hself : self.IsValid)
   }
   refine ⟨hres_valid, ?_⟩
   have ⟨hpx, hpy⟩ := EdwardsPoint.toPoint_of_isValid hres_valid
-  unfold AffinePoint.toPoint
+  unfold toPoint
   rw [dif_pos hself]
   ext
   · simp [hpx, hZ_F]

--- a/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/AsBytes.lean
+++ b/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/AsBytes.lean
@@ -1,34 +1,30 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Butterley
 -/
 import Curve25519Dalek.Funs
 
-/-! # as_bytes
+/-!
+# Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::as_bytes`
 
-Specification and proof for `CompressedEdwardsY::as_bytes`.
+This function exposes the internal 32-byte little-endian encoding stored inside a
+`CompressedEdwardsY`.
 
-This function returns a reference to the internal 32-byte array representation.
-
-Source: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
-open Aeneas Aeneas.Std Result Aeneas.Std.WP curve25519_dalek
-
+open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.edwards.CompressedEdwardsY
 
-/-! ## Specification for `CompressedEdwardsY::as_bytes`-/
-
-/-- **Spec for `edwards.CompressedEdwardsY.as_bytes`**:
-- The function succeeds (always returns `ok`)
-- The result is exactly the internal byte array representation.
+/-- **Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::as_bytes`**
+• The function succeeds (always returns `ok`)
+• The result is exactly the internal byte array representation
 -/
 @[step]
-theorem as_bytes_spec
-    (self : edwards.CompressedEdwardsY) :
-    as_bytes self ⦃ result =>
-    result = self ⦄ := by
+theorem as_bytes_spec (self : CompressedEdwardsY) :
+    as_bytes self ⦃ (result : Array U8 32#usize) =>
+      result = self ⦄ := by
   unfold as_bytes
   simp
 

--- a/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/CtEq.lean
+++ b/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/CtEq.lean
@@ -1,42 +1,27 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Specs.Edwards.CompressedEdwardsY.AsBytes
 
-/-! # Spec Theorem for `CompressedEdwardsY::ct_eq`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::ct_eq`
 
-Specification and proof for the `ConstantTimeEq` trait implementation for `CompressedEdwardsY`.
+Compares two `CompressedEdwardsY` values for equality in constant time by extracting
+the underlying 32-byte arrays via `as_bytes` (an identity operation), converting them
+to slices, and delegating to the slice-level constant-time equality comparison.
 
-This function performs constant-time equality comparison of two `CompressedEdwardsY` values
-by converting both to byte arrays via `as_bytes` (identity), converting to slices, and
-delegating to the slice-level constant-time comparison.
-
-**Source**: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.edwards.CompressedEdwardsY.Insts.SubtleConstantTimeEq
 
-/-
-natural language description:
-
-    • Compares two CompressedEdwardsY values for equality in constant time.
-
-    • Extracts the underlying 32-byte arrays via `as_bytes` (identity operation),
-      converts them to slices, and delegates to slice-level constant-time equality.
-
-natural language specs:
-
-    • The operation never panics (always returns successfully)
-    • Returns Choice.one iff the two CompressedEdwardsY values are equal
--/
-
-/-- **Spec and proof concerning `edwards.CompressedEdwardsY.Insts.SubtleConstantTimeEq.ct_eq`**:
-- No panic (always returns successfully)
-- The result is Choice.one iff the two CompressedEdwardsY values are equal
+/-- **Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::ct_eq`**
+• The operation never panics (always returns successfully)
+• Returns `Choice.one` iff the two `CompressedEdwardsY` values are equal
 -/
 @[step]
 theorem ct_eq_spec

--- a/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/Decompress.lean
+++ b/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/Decompress.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Dablander
 -/
@@ -12,90 +12,67 @@ import Curve25519Dalek.Specs.Edwards.CompressedEdwardsY.Step1
 import Curve25519Dalek.Specs.Edwards.CompressedEdwardsY.Step2
 import Curve25519Dalek.Specs.Edwards.CompressedEdwardsY.AsBytes
 
-/-! # Spec Theorem for `CompressedEdwardsY::decompress`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::decompress`
 
-Specification and proof for `CompressedEdwardsY::decompress`.
+Attempts to decompress a 32-byte array (`CompressedEdwardsY`) to an `EdwardsPoint` in
+extended twisted Edwards coordinates. The compressed representation encodes the
+y-coordinate in the low 255 bits (bytes 0–30 plus the low 7 bits of byte 31, in
+little-endian) and the sign (parity) of the x-coordinate in the high bit of byte 31.
+Decompression involves:
 
-Attempts to decompress a 32-byte array to an EdwardsPoint in extended twisted
-Edwards coordinates. The compressed representation encodes a y-coordinate in the low 255 bits
-and the sign (parity) of the x-coordinate in the high bit of byte 31. Decompression involves:
+- Extracting the y-coordinate from the byte array
+- Extracting the sign bit from the high bit of byte 31
+- Computing the (absolute value of the) x-coordinate from `y` by solving the curve
+  equation `-x² + y² = 1 + dx²y²` for `x²`
+- Adjusting the sign of `x` to match the encoded sign bit
+- Returning `ok none` if the input does not encode a valid Edwards point, otherwise
+  `ok (some ep)`
 
-1. Extracting the y-coordinate from the byte array
-2. Computing the (absolute value of the) x-coordinate using the curve equation ax² + y² = 1 + dx²y²
-3. Adjusting the sign of x based on the encoded sign bit
-
-Ported from the Verus spec in dalek-lite/curve25519-dalek/src/edwards.rs (lines 277-299),
-which asserts: is_valid_y ↔ is_some, well-formed point, Y = from_bytes, Z = 1, sign matching.
-
-**Source**: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-open curve25519_dalek.backend.serial.u64.field
-open Edwards
-
+open curve25519_dalek.backend.serial.u64.field Edwards
 namespace curve25519_dalek.edwards.CompressedEdwardsY
 
-/-
-Natural language description:
-
-    - Decompresses a CompressedEdwardsY (U8x32 byte array) to an EdwardsPoint in
-      extended coordinates
-    - Extracts the y-coordinate from bytes 0-30 and the low 7 bits of byte 31 (little-endian)
-    - Extracts the sign bit from the high bit of byte 31
-    - Computes x from y using the curve equation: given y, solve for x² in -x² + y² = 1 + dx²y²
-    - Adjusts the sign of x to match the encoded sign bit
-    - Returns "ok none" if the input does not encode a valid Edwards point, otherwise "ok (some ep)"
-
-Natural language specs (ported from Verus):
-
-    - The function always succeeds (no panic)
-    - Decompression succeeds (returns some) iff the y-coordinate is valid (a curve point exists)
-    - When successful, the returned EdwardsPoint satisfies:
-      - Y.toField = the y-coordinate encoded in the input bytes (mod p)
-      - Z.toField = 1
-      - The point is valid: ep.IsValid (curve equation, T = XY/Z, bounds, Z ≠ 0)
-      - The sign of X matches the sign bit (when y² ≠ 1 in the field)
--/
-
-/-- **Spec for `edwards.CompressedEdwardsY.decompress`**. No panic (always returns successfully).
-
-Let `y : CurveField` be the y-coordinate encoded in the low 255 bits of `cey`, and let
-`x_sign_bit` be bit 7 of byte 31 (the encoded sign of x).
-
-**Success condition.** Decompression returns `some` iff `y` is a valid Edwards
-y-coordinate, i.e. some curve point has that y value.
-
-**On success** (`result = some ep`):
-- `ep.IsValid` — full validity invariant (curve equation, `T = XY/Z`, bounds, `Z ≠ 0`)
-- `ep.Y.toField = y` and `Field51_as_Nat ep.Y ≡ (U8x32_as_Nat cey % 2^255) [MOD p]` —
-  `Y` matches the encoded y-coordinate at both the `ZMod` and `Nat` levels
-- `ep.Z.toField = 1` and `Field51_as_Nat ep.Z % p = 1` — `Z` is the field element 1
-- When `y^2 ≠ 1` (the non-degenerate case where `x ≠ 0`):
-  `x_sign_bit ↔ (Field51_as_Nat ep.X % p) % 2 = 1` — sign of `X` matches bit 255 of the input.
+/-- **Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::decompress`**
+• The function always succeeds (no panic)
+• Decompression returns `some` iff the encoded `y` (the low 255 bits of `self`) is a
+  valid Edwards y-coordinate, i.e. some curve point has that y value
+• On success, `ep.IsValid` holds (curve equation, `T = XY/Z`, bounds, `Z ≠ 0`)
+• On success, `ep.Y.toField = y` — `Y` matches the encoded y-coordinate at the
+  `ZMod` level
+• On success, `Field51_as_Nat ep.Y ≡ (U8x32_as_Nat self % 2^255) [MOD p]` — same
+  equality at the `Nat` level
+• On success, `ep.Z.toField = 1` — `Z` is the field element 1
+• On success, `Field51_as_Nat ep.Z % p = 1` — same equality at the `Nat` level
+• On success, when `y² ≠ 1` (the non-degenerate case where `x ≠ 0`), the encoded
+  sign bit (bit 7 of byte 31) matches the parity of `X`:
+  `x_sign_bit ↔ (Field51_as_Nat ep.X % p) % 2 = 1`
 -/
 @[step]
-theorem decompress_spec (cey : edwards.CompressedEdwardsY) :
-    edwards.CompressedEdwardsY.decompress cey ⦃ result =>
-      let y : CurveField := ((U8x32_as_Nat cey % 2 ^ 255 : Nat) : CurveField)
-      let x_sign_bit := cey[31]!.val.testBit 7
+theorem decompress_spec (self : CompressedEdwardsY) :
+    decompress self ⦃ (result : Option EdwardsPoint) =>
+      let y : CurveField := ((U8x32_as_Nat self % 2 ^ 255 : Nat) : CurveField)
+      let x_sign_bit := self[31]!.val.testBit 7
       (result.isSome ↔ ∃ pt : Point Ed25519, pt.y = y) ∧
       (∀ ep, result = some ep →
         ep.IsValid ∧
         ep.Y.toField = y ∧
-        Field51_as_Nat ep.Y ≡ (U8x32_as_Nat cey % 2 ^ 255) [MOD p] ∧
+        Field51_as_Nat ep.Y ≡ (U8x32_as_Nat self % 2 ^ 255) [MOD p] ∧
         ep.Z.toField = 1 ∧
         Field51_as_Nat ep.Z % p = 1 ∧
         (y ^ 2 ≠ 1 →
           (x_sign_bit ↔ (Field51_as_Nat ep.X % p) % 2 = 1))) ⦄ := by
-  unfold edwards.CompressedEdwardsY.decompress
+  unfold decompress
   -- Compose step_1_spec (explicit `let*` to avoid Pattern-8 self-recursion of `@[step]`)
   let* ⟨res1, post1⟩ ← step_1_spec
   obtain ⟨is_valid, X, Y, Z⟩ := res1
   obtain ⟨Y_mod, Y_bounds, Z_val, Z_bounds, X_bounds, X_parity, flag_iff, flag_curve⟩ := post1
   simp only [step_simps]
   -- Nat → CurveField bridges for Y and Z
-  have hY_toField : Y.toField = ((U8x32_as_Nat cey % 2 ^ 255 : Nat) : CurveField) := by
+  have hY_toField : Y.toField = ((U8x32_as_Nat self % 2 ^ 255 : Nat) : CurveField) := by
     simp only [FieldElement51.toField]
     exact lift_mod_eq _ _ Y_mod
   have hZ_toField : Z.toField = 1 := by
@@ -105,11 +82,11 @@ theorem decompress_spec (cey : edwards.CompressedEdwardsY) :
     -- Chain step_2_spec
     have ⟨ep, h_step2_eq, ep_Y_eq, ep_Z_eq, ep_X_cond, ep_X_bounds, ep_T_eq, ep_T_bounds⟩ :=
       spec_imp_exists
-        (step_2_spec cey X Y Z cey (cey[31]!.val.testBit 7) rfl rfl X_bounds Y_bounds)
+        (step_2_spec self X Y Z self (self[31]!.val.testBit 7) rfl rfl X_bounds Y_bounds)
     rw [h_step2_eq]
     -- Sign-invariant X² bridge: `(±X).toField² = X.toField²`
     have hX_sq : ep.X.toField ^ 2 = X.toField ^ 2 := by
-      rcases hst : cey[31]!.val.testBit 7 with _ | _
+      rcases hst : self[31]!.val.testBit 7 with _ | _
       · simp only [hst] at ep_X_cond
         rw [ep_X_cond]
       · simp only [hst, ite_true] at ep_X_cond
@@ -150,7 +127,7 @@ theorem decompress_spec (cey : edwards.CompressedEdwardsY) :
       · rw [ep_Z_eq, Z_val]; unfold p; decide          -- Field51_as_Nat ep.Z % p = 1
       · -- Sign-bit ↔ parity (non-degenerate: y² ≠ 1)
         intro h_ysq_ne_1
-        rcases hst : cey[31]!.val.testBit 7 with _ | _
+        rcases hst : self[31]!.val.testBit 7 with _ | _
         · -- sign_bit = false: ep.X = X, so parity = 0 (from step_1 post 6)
           simp only [hst] at ep_X_cond
           rw [ep_X_cond, X_parity]; simp

--- a/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/FromSlice.lean
+++ b/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/FromSlice.lean
@@ -1,59 +1,37 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Specs.Ristretto.CompressedRistretto.FromSlice
 
-/-! # Spec Theorem for `CompressedEdwardsY::from_slice`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::from_slice`
 
-Specification and proof for the `from_slice` method on `CompressedEdwardsY`.
-
-This function constructs a `CompressedEdwardsY` from a byte slice by attempting to convert
+Constructs a `CompressedEdwardsY` from a byte slice by attempting to convert
 the slice into a 32-byte array via `TryFrom`. If the slice has exactly 32 bytes, it returns
 `Ok(CompressedEdwardsY(bytes))`; otherwise it returns `Err(TryFromSliceError)`.
 
 The function never panics — it always succeeds at the Aeneas `Result` level. The inner
 `core.result.Result` signals success or failure of the byte-to-array conversion.
 
-**Source**: curve25519-dalek/src/edwards.rs
-
-**Dependencies**:
-- `core.array.TryFromArrayCopySlice.try_from` (Aeneas library, has definition)
-- `core.result.Result.map` (axiom in FunsExternal.lean — needs spec for proof)
-- `from_slice.closure.call_once` (identity closure, `ok tupled_args`)
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.edwards.CompressedEdwardsY
 
-/-
-natural language description:
-
-    • Constructs a `CompressedEdwardsY` from a byte slice `bytes`.
-    • Internally, tries to convert the slice into a `[u8; 32]` array via `TryFrom`.
-    • If the slice has exactly 32 bytes, returns `Ok(CompressedEdwardsY(bytes))`.
-    • If the slice does not have exactly 32 bytes, returns `Err(TryFromSliceError)`.
-    • The function never panics — it always succeeds at the Aeneas `Result` level.
-    • The inner Rust-level `core::result::Result` signals success or failure.
-
-natural language specs:
-
-    • The operation never panics (always returns `ok` at the Aeneas level)
-    • If bytes.length = 32: the result is Ok(cey) where cey.val = bytes.val
-    • If bytes.length ≠ 32: the result is Err(())
--/
-
-/-- **Spec and proof concerning `edwards.CompressedEdwardsY.from_slice`**:
-    • The operation never panics (always returns `ok` at the Aeneas level)
-    • If bytes.length = 32: the result is Ok(cey) where cey.val = bytes.val
-    • If bytes.length ≠ 32: the result is Err(())
+/-- **Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::from_slice`**
+• The operation never panics (always returns `.ok` at the Aeneas level)
+• If `bytes.length = 32`: the `result` is `.Ok cey` where `cey.val = bytes.val`
+• If `bytes.length ≠ 32`: the `result` is `.Err ()`
 -/
 @[step]
 theorem from_slice_spec
     (bytes : Slice U8) :
-    from_slice bytes ⦃ (result : core.result.Result CompressedEdwardsY core.array.TryFromSliceError) =>
+    from_slice bytes ⦃
+      (result : core.result.Result CompressedEdwardsY core.array.TryFromSliceError) =>
       (bytes.length = 32 → ∃ cey : CompressedEdwardsY, result = .Ok cey ∧ cey.val = bytes.val) ∧
       (bytes.length ≠ 32 → result = .Err ()) ⦄ := by
   unfold from_slice

--- a/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/Identity.lean
+++ b/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/Identity.lean
@@ -1,53 +1,37 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 
+/-!
+# Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::identity`
 
-/-! # identity
+Returns the identity element of the Edwards curve as a `CompressedEdwardsY`
+(a 32-byte array encoding the Y-coordinate in little-endian form).
 
-Specification and proof for `CompressedEdwardsY::identity`.
+The identity point on the twisted Edwards curve `ax² + y² = 1 + dx²y²` has
+affine coordinates `(x, y) = (0, 1)`. When compressed, only the Y-coordinate
+is stored (with the sign bit of `x` in the high bit of byte 31); since
+`x = 0`, the sign bit is 0, so the little-endian encoding is
+`[1, 0, 0, ..., 0]` (32 bytes).
 
-This function returns the identity element of the Edwards curve as a compressed
-Edwards Y coordinate (a 32-byte little-endian encoding).
-
-**Source**: curve25519-dalek/src/edwards.rs:L393-L398
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
-open Aeneas Aeneas.Std Result Aeneas.Std.WP curve25519_dalek
+open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.edwards.CompressedEdwardsY.Insts.Curve25519_dalekTraitsIdentity
 
-/-
-natural language description:
-
-• Returns the identity element of the Edwards curve as a CompressedEdwardsY
-  (a 32-byte array encoding the Y-coordinate in little-endian form)
-
-natural language specs:
-
-• The function always succeeds (no panic)
-• The resulting CompressedEdwardsY is a 32-byte array: [1, 0, 0, ..., 0]
-• This is the little-endian encoding of Y = 1, which is the Y-coordinate
-  of the identity point on the twisted Edwards curve
-• The identity point on the twisted Edwards curve ax² + y² = 1 + dx²y²
-  has affine coordinates (x, y) = (0, 1)
-• When compressed, only the Y-coordinate is stored (with the sign bit of x
-  in the high bit of byte 31); since x = 0, the sign bit is 0
-• The little-endian encoding of Y = 1 is [1, 0, 0, ..., 0] (32 bytes)
--/
-
-/-- **Spec and proof** concerning:
-`edwards.CompressedEdwardsY.Insts.Curve25519_dalekTraitsIdentity.identity`
-- No panic (always returns successfully)
-- The resulting CompressedEdwardsY encodes the value 1 (the Y-coordinate of the identity point)
+/-- **Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::identity`**
+• No panic (always returns successfully)
+• The resulting `CompressedEdwardsY` encodes the value 1 (the Y-coordinate of the identity point)
 -/
 @[step]
 theorem identity_spec :
-    identity ⦃ (q : edwards.CompressedEdwardsY) =>
-      U8x32_as_Nat q = 1 ⦄ := by
+    identity ⦃ (result : CompressedEdwardsY) =>
+      U8x32_as_Nat result = 1 ⦄ := by
   unfold identity
   simp [U8x32_as_Nat, Array.make, Finset.sum_range_succ]
 

--- a/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/Step1.lean
+++ b/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/Step1.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: AI Assistant
+Authors: TBA
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
@@ -16,26 +16,26 @@ import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Add
 import Curve25519Dalek.Specs.Backend.Serial.U64.Constants.EdwardsD
 import Curve25519Dalek.Specs.Field.FieldElement51.SqrtRatioi
 
-/-! # Spec Theorem for `CompressedEdwardsY::decompress::step_1`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::decompress::step_1`
 
-Specification for the first step of `CompressedEdwardsY::decompress`.
+The first step of `CompressedEdwardsY::decompress`. Given a 32-byte
+`CompressedEdwardsY` input, this function:
 
-This function performs the initial decompression step which:
-1. Extracts the y-coordinate from the compressed representation
-2. Computes u = y² - 1
-3. Computes v = dy² + 1 where d is the Edwards curve constant
-4. Computes the x-coordinate using sqrt_ratio_i(u, v)
-5. Returns a validity flag and the coordinates (X, Y, Z)
+- Extracts the y-coordinate `Y` from the byte array via `from_bytes` (masking
+  the top bit)
+- Sets `Z = 1` (projective coordinate)
+- Computes `YY = Y²`
+- Computes `u = YY - Z = y² - 1`
+- Computes `v = d·YY + Z = d·y² + 1`, where `d` is the Edwards curve constant
+- Computes `(is_valid_y_coord, X) = sqrt_ratio_i(u, v)`
+- Returns `(is_valid_y_coord, X, Y, Z)`
 
-The twisted Edwards curve equation is: -x² + y² = 1 + d·x²·y²
-Rearranging for x²: x² = (y² - 1) / (d·y² + 1)
-So u is the numerator and v the denominator of x².
+The twisted Edwards curve equation `-x² + y² = 1 + d·x²·y²` rearranges to
+`x² = (y² - 1) / (d·y² + 1)`, so `u` is the numerator and `v` the denominator
+of `x²`.
 
-Ported from the Verus spec in dalek-lite/curve25519-dalek/src/edwards.rs (lines 359-392),
-which asserts curve-level properties: `is_on_edwards_curve(X, Y)` and
-`is_valid_edwards_y_coordinate(Y)`.
-
-**Source**: curve25519-dalek/src/edwards.rs, lines 216-227
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
@@ -47,55 +47,31 @@ open curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithAddSharedAFieldEle
 open curve25519_dalek.backend.serial.u64.field
 open curve25519_dalek.field.FieldElement51
 open Edwards
-
 namespace curve25519_dalek.edwards.CompressedEdwardsY
 
-/-
-Natural language description:
-
-    - Takes a CompressedEdwardsY (32-byte array) as input
-    - Extracts the y-coordinate from the byte array via from_bytes (masks top bit)
-    - Sets Z = 1 (projective coordinate)
-    - Computes YY = Y²
-    - Computes u = YY - Z = y² - 1
-    - Computes v = d·YY + Z = d·y² + 1, where d is the Edwards curve constant
-    - Computes (is_valid_y_coord, X) = sqrt_ratio_i(u, v)
-    - Returns (is_valid_y_coord, X, Y, Z)
-
-Natural language specs (ported from Verus):
-
-    - The function always succeeds (no panic) for any 32-byte input
-    - Y encodes the y-coordinate from the input bytes (mod p)
-    - Z = 1 (the multiplicative identity)
-    - is_valid_y_coord = 1 iff there exists an x such that (x, y) is on the curve
-    - If is_valid_y_coord = 1, then (X, Y) is on the twisted Edwards curve
-    - X has even parity (non-negative square root)
-    - Output bounds: Y limbs < 2^51, Z limbs < 2^51, X limbs ≤ 2^53-1
--/
-
-/-- **Spec for `edwards.decompress.step_1`**. No panic.
-
-Returns a tuple `(is_valid_y_coord, X, Y, Z)` — let `x := X.toField`, `y := Y.toField`.
-
-- `Y` is the field element decoded from the low 255 bits of `cey`:
-  `Field51_as_Nat Y ≡ (U8x32_as_Nat cey % 2^255) [MOD p]`, with `Y` limbs `< 2^51`.
-- `Z` is the multiplicative identity: `Field51_as_Nat Z = 1`, with `Z` limbs `< 2^51`.
-- `X` is the non-negative square root produced by `sqrt_ratio_i`:
-  limbs `≤ 2^53 - 1` (inherited from `sqrt_ratio_i_spec'` — see
-  `Ed_audit_ref/README.md` DEFER-1), parity `(Field51_as_Nat X % p) % 2 = 0`.
-- `is_valid_y_coord.val = 1` iff `y` is a valid Edwards y-coordinate, i.e. there
-  exists some `x'` satisfying the twisted Edwards curve equation
-  `a·x'^2 + y^2 = 1 + d·x'^2·y^2`.
-- When valid, the specific square root returned by `sqrt_ratio_i`, namely `(x, y)`,
-  satisfies that same equation.
+/-- **Spec theorem for `curve25519_dalek::edwards::decompress::step_1`**
+• The function always succeeds (no panic) for any 32-byte input
+• `Y` decodes the low 255 bits of `repr`:
+  `Field51_as_Nat Y ≡ (U8x32_as_Nat repr % 2^255) [MOD p]`
+• `Y` limbs are reduced: `∀ i < 5, Y[i]!.val < 2^51`
+• `Z` is the multiplicative identity: `Field51_as_Nat Z = 1`
+• `Z` limbs are reduced: `∀ i < 5, Z[i]!.val < 2^51`
+• `X` (the non-negative square root produced by `sqrt_ratio_i`) has bounded
+  limbs: `∀ i < 5, X[i]!.val ≤ 2^53 - 1`
+• `X` has even parity: `(Field51_as_Nat X % p) % 2 = 0`
+• `is_valid_y_coord.val = 1` iff the encoded `y` is a valid Edwards
+  y-coordinate, i.e. some `x'` satisfies `a·x'² + y² = 1 + d·x'²·y²`
+• When `is_valid_y_coord.val = 1`, the returned `(x, y)` (with
+  `x := X.toField`, `y := Y.toField`) satisfies `a·x² + y² = 1 + d·x²·y²`
 -/
 @[step]
-theorem step_1_spec (cey : edwards.CompressedEdwardsY) :
-    edwards.decompress.step_1 cey ⦃ result =>
+theorem step_1_spec (repr : CompressedEdwardsY) :
+    decompress.step_1 repr ⦃ (result : subtle.Choice ×
+        FieldElement51 × FieldElement51 × FieldElement51) =>
       let (is_valid_y_coord, X, Y, Z) := result
       let x := X.toField
       let y := Y.toField
-      Field51_as_Nat Y ≡ (U8x32_as_Nat cey % 2 ^ 255) [MOD p] ∧
+      Field51_as_Nat Y ≡ (U8x32_as_Nat repr % 2 ^ 255) [MOD p] ∧
       (∀ i < 5, Y[i]!.val < 2 ^ 51) ∧
       Field51_as_Nat Z = 1 ∧
       (∀ i < 5, Z[i]!.val < 2 ^ 51) ∧
@@ -105,8 +81,8 @@ theorem step_1_spec (cey : edwards.CompressedEdwardsY) :
         ∃ x' : CurveField, Ed25519.a * x' ^ 2 + y ^ 2 = 1 + Ed25519.d * x' ^ 2 * y ^ 2) ∧
       (is_valid_y_coord.val = 1#u8 →
         Ed25519.a * x ^ 2 + y ^ 2 = 1 + Ed25519.d * x ^ 2 * y ^ 2) ⦄ := by
-  unfold edwards.decompress.step_1
-  let* ⟨ a, a_post ⟩ ← edwards.CompressedEdwardsY.as_bytes_spec
+  unfold decompress.step_1
+  let* ⟨ a, a_post ⟩ ← as_bytes_spec
   let* ⟨ Y, Y_mod, Y_bounds ⟩ ← from_bytes_spec
   let* ⟨ Z, Z_val, Z_bounds ⟩ ← ONE_spec
   let* ⟨ YY, YY_mod, YY_bounds ⟩ ← square_spec
@@ -191,7 +167,7 @@ theorem step_1_spec (cey : edwards.CompressedEdwardsY) :
           rw [hf0] at h_flag; exact absurd h_flag (by decide)
   -- Discharge the 8 postconditions
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-  · -- 1. Field51_as_Nat Y ≡ (U8x32_as_Nat cey % 2^255) [MOD p]
+  · -- 1. Field51_as_Nat Y ≡ (U8x32_as_Nat repr % 2^255) [MOD p]
     rw [a_post] at Y_mod
     exact Y_mod
   · -- 2. ∀ i < 5, Y[i]!.val < 2^51

--- a/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/Step2.lean
+++ b/Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/Step2.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Filippo A. E. Nuccio
 -/
@@ -11,21 +11,23 @@ import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Neg
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ConditionalAssign
 
-/-! # Spec Theorem for `CompressedEdwardsY::decompress::step_2`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::decompress::step_2`
 
-Specification and proof for the second step of `CompressedEdwardsY::decompress`.
+The final step of `CompressedEdwardsY::decompress`. Given a `CompressedEdwardsY`
+together with the field elements `X`, `Y`, `Z` produced by `step_1`, this
+function:
 
-This function performs the final decompression step which:
-1. Extracts the sign bit from the compressed representation (byte 31, bit 7)
-2. Conditionally negates the x-coordinate according to the sign bit
-3. Computes T = X * Y
-4. Returns the complete EdwardsPoint in extended coordinates (X, Y, Z, T)
+- Takes a `CompressedEdwardsY` and field elements `X`, `Y`, `Z` from `step_1`
+- Extracts the sign bit from the high bit of byte 31 of the compressed
+  representation
+- Since `sqrt_ratio_i` returns the nonnegative square root, conditionally
+  negates `X` according to the sign bit so that the recovered x-coordinate
+  matches the encoded sign
+- Computes `T = X * Y` (the product of the x and y coordinates)
+- Returns an `EdwardsPoint` in extended coordinates `(X, Y, Z, T)`
 
-Ported from the Verus spec in dalek-lite/curve25519-dalek/src/edwards.rs (lines 507-539),
-which asserts: result.X = if sign then field_neg(X) else X, result.T = field_mul(result.X, Y),
-Y and Z unchanged, limb bounds 52-bit.
-
-**Source**: curve25519-dalek/src/edwards.rs, lines 230-248
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
@@ -33,27 +35,7 @@ open curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithMulSharedAFieldEle
 open curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithNegFieldElement51
 open curve25519_dalek.backend.serial.u64.field
 open Edwards
-
 namespace curve25519_dalek.edwards.CompressedEdwardsY
-
-/-
-Natural language description:
-
-    - Takes a CompressedEdwardsY and field elements X, Y, Z from step_1
-    - Extracts the sign bit from the high bit of byte 31 of the compressed representation
-    - Since sqrt_ratio_i returns the nonnegative square root, conditionally negates X
-      according to the sign bit to match the encoded sign
-    - Computes T = X * Y (the product of x and y coordinates)
-    - Returns an EdwardsPoint with coordinates (X, Y, Z, T)
-
-Natural language specs (ported from Verus):
-
-    - The function always succeeds (no panic) given bounded inputs
-    - result.X.toField = if sign_bit then -X.toField else X.toField
-    - result.T.toField = result.X.toField * Y.toField
-    - Y and Z are unchanged
-    - Output bounds: result.X limbs ≤ 2^53-1, result.T limbs < 2^52
--/
 
 private lemma toField_neg
     {X xneg : FieldElement51}
@@ -75,27 +57,28 @@ private lemma toField_mul
   have heq := lift_mod_eq _ _ h
   push_cast at heq; exact heq
 
-/-- **Spec for `edwards.decompress.step_2`** (ported from Verus):
-- Returns an EdwardsPoint with coordinates (X', Y, Z, T) where:
-  - Y and Z are unchanged from the inputs
-  - X'.toField = if sign_bit then -X.toField else X.toField
-  - X' limbs ≤ 2^53 - 1
-  - T.toField = X'.toField * Y.toField
-  - T limbs < 2^52
+/-- **Spec theorem for `curve25519_dalek::edwards::decompress::step_2`**
+• The function always succeeds (no panic) given the bounded inputs `hX` and `hY`
+• `result.Y = Y` is unchanged
+• `result.Z = Z` is unchanged
+• If `sign_bit` is true then `result.X.toField = -X.toField`, else `result.X = X`
+• `result.X` has bounded limbs: `∀ i < 5, result.X[i]!.val ≤ 2^53 - 1`
+• `result.T.toField = result.X.toField * Y.toField`
+• `result.T` has bounded limbs: `∀ i < 5, result.T[i]!.val < 2^52`
 -/
 @[step]
 theorem step_2_spec
-    (repr : edwards.CompressedEdwardsY)
-    (X : backend.serial.u64.field.FieldElement51)
-    (Y : backend.serial.u64.field.FieldElement51)
-    (Z : backend.serial.u64.field.FieldElement51)
-    (bytes : Aeneas.Std.Array U8 32#usize)
+    (repr : CompressedEdwardsY)
+    (X : FieldElement51)
+    (Y : FieldElement51)
+    (Z : FieldElement51)
+    (bytes : Array U8 32#usize)
     (sign_bit : Bool)
     (h_repr : repr.as_bytes = ok bytes)
     (h_byter : sign_bit = (bytes[31]!.val.testBit 7))
     (hX : ∀ i < 5, X[i]!.val ≤ 2 ^ 53 - 1)
     (hY : ∀ i < 5, Y[i]!.val < 2 ^ 51) :
-    edwards.decompress.step_2 repr X Y Z ⦃ result =>
+    edwards.decompress.step_2 repr X Y Z ⦃ (result : EdwardsPoint) =>
       result.Y = Y ∧
       result.Z = Z ∧
       (if sign_bit then

--- a/functions.json
+++ b/functions.json
@@ -5156,11 +5156,11 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem identity_spec :\n    identity ⦃ (q : edwards.CompressedEdwardsY) =>\n      U8x32_as_Nat q = 1 ⦄ := by ...",
+   "theorem identity_spec :\n    identity ⦃ (result : CompressedEdwardsY) =>\n      U8x32_as_Nat result = 1 ⦄ := by ...",
    "spec_file":
    "Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/Identity.lean",
    "spec_docstring":
-   "/-- **Spec and proof** concerning:\n`edwards.CompressedEdwardsY.Insts.Curve25519_dalekTraitsIdentity.identity`\n- No panic (always returns successfully)\n- The resulting CompressedEdwardsY encodes the value 1 (the Y-coordinate of the identity point)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::identity`**\n• No panic (always returns successfully)\n• The resulting `CompressedEdwardsY` encodes the value 1 (the Y-coordinate of the identity point)\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::traits::Identity for curve25519_dalek::edwards::CompressedEdwardsY}::identity",
@@ -5201,7 +5201,7 @@
    "theorem ct_eq_spec\n    (self other : CompressedEdwardsY) :\n    ct_eq self other ⦃ (result : subtle.Choice) =>\n      result = Choice.one ↔ self = other ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/CtEq.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.CompressedEdwardsY.Insts.SubtleConstantTimeEq.ct_eq`**:\n- No panic (always returns successfully)\n- The result is Choice.one iff the two CompressedEdwardsY values are equal\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::ct_eq`**\n• The operation never panics (always returns successfully)\n• Returns `Choice.one` iff the two `CompressedEdwardsY` values are equal\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{subtle::ConstantTimeEq for curve25519_dalek::edwards::CompressedEdwardsY}::ct_eq",
@@ -5219,10 +5219,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem as_bytes_spec\n    (self : edwards.CompressedEdwardsY) :\n    as_bytes self ⦃ result =>\n    result = self ⦄ := by ...",
+   "theorem as_bytes_spec (self : CompressedEdwardsY) :\n    as_bytes self ⦃ (result : Array U8 32#usize) =>\n      result = self ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/AsBytes.lean",
    "spec_docstring":
-   "/-- **Spec for `edwards.CompressedEdwardsY.as_bytes`**:\n- The function succeeds (always returns `ok`)\n- The result is exactly the internal byte array representation.\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::as_bytes`**\n• The function succeeds (always returns `ok`)\n• The result is exactly the internal byte array representation\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::CompressedEdwardsY}::as_bytes",
@@ -5239,11 +5239,11 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem decompress_spec (cey : edwards.CompressedEdwardsY) :\n    edwards.CompressedEdwardsY.decompress cey ⦃ result =>\n      let y : CurveField := ((U8x32_as_Nat cey % 2 ^ 255 : Nat) : CurveField)\n      let x_sign_bit := cey[31]!.val.testBit 7\n      (result.isSome ↔ ∃ pt : Point Ed25519, pt.y = y) ∧\n      (∀ ep, result = some ep →\n        ep.IsValid ∧\n        ep.Y.toField = y ∧\n        Field51_as_Nat ep.Y ≡ (U8x32_as_Nat cey % 2 ^ 255) [MOD p] ∧\n        ep.Z.toField = 1 ∧\n        Field51_as_Nat ep.Z % p = 1 ∧\n        (y ^ 2 ≠ 1 →\n          (x_sign_bit ↔ (Field51_as_Nat ep.X % p) % 2 = 1))) ⦄ := by ...",
+   "theorem decompress_spec (self : CompressedEdwardsY) :\n    decompress self ⦃ (result : Option EdwardsPoint) =>\n      let y : CurveField := ((U8x32_as_Nat self % 2 ^ 255 : Nat) : CurveField)\n      let x_sign_bit := self[31]!.val.testBit 7\n      (result.isSome ↔ ∃ pt : Point Ed25519, pt.y = y) ∧\n      (∀ ep, result = some ep →\n        ep.IsValid ∧\n        ep.Y.toField = y ∧\n        Field51_as_Nat ep.Y ≡ (U8x32_as_Nat self % 2 ^ 255) [MOD p] ∧\n        ep.Z.toField = 1 ∧\n        Field51_as_Nat ep.Z % p = 1 ∧\n        (y ^ 2 ≠ 1 →\n          (x_sign_bit ↔ (Field51_as_Nat ep.X % p) % 2 = 1))) ⦄ := by ...",
    "spec_file":
    "Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/Decompress.lean",
    "spec_docstring":
-   "/-- **Spec for `edwards.CompressedEdwardsY.decompress`**. No panic (always returns successfully).\n\nLet `y : CurveField` be the y-coordinate encoded in the low 255 bits of `cey`, and let\n`x_sign_bit` be bit 7 of byte 31 (the encoded sign of x).\n\n**Success condition.** Decompression returns `some` iff `y` is a valid Edwards\ny-coordinate, i.e. some curve point has that y value.\n\n**On success** (`result = some ep`):\n- `ep.IsValid` — full validity invariant (curve equation, `T = XY/Z`, bounds, `Z ≠ 0`)\n- `ep.Y.toField = y` and `Field51_as_Nat ep.Y ≡ (U8x32_as_Nat cey % 2^255) [MOD p]` —\n  `Y` matches the encoded y-coordinate at both the `ZMod` and `Nat` levels\n- `ep.Z.toField = 1` and `Field51_as_Nat ep.Z % p = 1` — `Z` is the field element 1\n- When `y^2 ≠ 1` (the non-degenerate case where `x ≠ 0`):\n  `x_sign_bit ↔ (Field51_as_Nat ep.X % p) % 2 = 1` — sign of `X` matches bit 255 of the input.\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::decompress`**\n• The function always succeeds (no panic)\n• Decompression returns `some` iff the encoded `y` (the low 255 bits of `self`) is a\n  valid Edwards y-coordinate, i.e. some curve point has that y value\n• On success, `ep.IsValid` holds (curve equation, `T = XY/Z`, bounds, `Z ≠ 0`)\n• On success, `ep.Y.toField = y` — `Y` matches the encoded y-coordinate at the\n  `ZMod` level\n• On success, `Field51_as_Nat ep.Y ≡ (U8x32_as_Nat self % 2^255) [MOD p]` — same\n  equality at the `Nat` level\n• On success, `ep.Z.toField = 1` — `Z` is the field element 1\n• On success, `Field51_as_Nat ep.Z % p = 1` — same equality at the `Nat` level\n• On success, when `y² ≠ 1` (the non-degenerate case where `x ≠ 0`), the encoded\n  sign bit (bit 7 of byte 31) matches the parity of `X`:\n  `x_sign_bit ↔ (Field51_as_Nat ep.X % p) % 2 = 1`\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::CompressedEdwardsY}::decompress",
@@ -5262,11 +5262,11 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem from_slice_spec\n    (bytes : Slice U8) :\n    from_slice bytes ⦃ (result : core.result.Result CompressedEdwardsY core.array.TryFromSliceError) =>\n      (bytes.length = 32 → ∃ cey : CompressedEdwardsY, result = .Ok cey ∧ cey.val = bytes.val) ∧\n      (bytes.length ≠ 32 → result = .Err ()) ⦄ := by ...",
+   "theorem from_slice_spec\n    (bytes : Slice U8) :\n    from_slice bytes ⦃\n      (result : core.result.Result CompressedEdwardsY core.array.TryFromSliceError) =>\n      (bytes.length = 32 → ∃ cey : CompressedEdwardsY, result = .Ok cey ∧ cey.val = bytes.val) ∧\n      (bytes.length ≠ 32 → result = .Err ()) ⦄ := by ...",
    "spec_file":
    "Curve25519Dalek/Specs/Edwards/CompressedEdwardsY/FromSlice.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.CompressedEdwardsY.from_slice`**:\n    • The operation never panics (always returns `ok` at the Aeneas level)\n    • If bytes.length = 32: the result is Ok(cey) where cey.val = bytes.val\n    • If bytes.length ≠ 32: the result is Err(())\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::CompressedEdwardsY::from_slice`**\n• The operation never panics (always returns `.ok` at the Aeneas level)\n• If `bytes.length = 32`: the `result` is `.Ok cey` where `cey.val = bytes.val`\n• If `bytes.length ≠ 32`: the `result` is `.Err ()`\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::CompressedEdwardsY}::from_slice",
@@ -6617,10 +6617,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem eq_spec (self other : AffinePoint) (h_self_valid : self.IsValid)\n    (h_other_valid : other.IsValid) :\n    eq self other ⦃ result =>\n    result = true ↔ self.toPoint = other.toPoint ⦄ := by ...",
+   "theorem eq_spec (self other : AffinePoint) (h_self_valid : self.IsValid)\n    (h_other_valid : other.IsValid) :\n    eq self other ⦃ (result : Bool) =>\n      result = true ↔ self.toPoint = other.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/Eq.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.affine.PartialEqAffinePoint.eq`**:\n• The function always succeeds (no panic) for valid inputs\n• The result is `true` if and only if the two points represent the same point on the curve\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::eq`**\n• The function always succeeds (no panic) for valid input affine Edwards points\n• The result is `true` if and only if the two points represent the same point on the curve\n-/",
    "source": "curve25519-dalek/src/edwards/affine.rs",
    "rust_name":
    "curve25519_dalek::edwards::affine::{core::cmp::PartialEq<curve25519_dalek::edwards::affine::AffinePoint> for curve25519_dalek::edwards::affine::AffinePoint}::eq",
@@ -6719,11 +6719,11 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem identity_spec :\n    identity ⦃ (q : AffinePoint) =>\n      Field51_as_Nat q.x = 0 ∧ Field51_as_Nat q.y = 1 ∧\n      q.IsValid ∧ q.toPoint = 0 ⦄ := by ...",
+   "theorem identity_spec :\n    identity ⦃ (q : AffinePoint) =>\n      Field51_as_Nat q.x = 0 ∧\n      Field51_as_Nat q.y = 1 ∧\n      q.IsValid ∧\n      q.toPoint = 0 ⦄ := by ...",
    "spec_file":
    "Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/Identity.lean",
    "spec_docstring":
-   "/-- **Spec and proof** concerning:\n`edwards.affine.AffinePoint.Insts.Curve25519_dalekTraitsIdentity.identity`\n- No panic (always returns successfully)\n- The resulting AffinePoint is the identity element of the Ed25519 group\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::identity`**\n• The function always succeeds (no panic)\n• The x-coordinate of the result is `0`\n• The y-coordinate of the result is `1`\n• The resulting `AffinePoint` is valid\n• The result represents the identity element of the Ed25519 group\n-/",
    "source": "curve25519-dalek/src/edwards/affine.rs",
    "rust_name":
    "curve25519_dalek::edwards::affine::{curve25519_dalek::traits::Identity for curve25519_dalek::edwards::affine::AffinePoint}::identity",
@@ -6764,11 +6764,11 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem conditional_select_spec\n    (a b : edwards.affine.AffinePoint)\n    (choice : subtle.Choice) :\n    conditional_select a b choice ⦃ (result : edwards.affine.AffinePoint) =>\n      result = if choice.val = 1#u8 then b else a ⦄ := by ...",
+   "theorem conditional_select_spec (a b : AffinePoint) (choice : subtle.Choice) :\n    conditional_select a b choice ⦃ (result : AffinePoint) =>\n      result = if choice.val = 1#u8 then b else a ⦄ := by ...",
    "spec_file":
    "Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/ConditionalSelect.lean",
    "spec_docstring":
-   "/--\n**Spec and proof** concerning:\n`edwards.affine.AffinePoint.Insts.SubtleConditionallySelectable.conditional_select`:\n- No panic (always returns successfully)\n- Returns `b` when `choice = 1` and `a` when `choice = 0`\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::conditional_select`**\n• No panic (always returns successfully)\n• Returns `b` when `choice = 1` and `a` when `choice = 0`\n-/",
    "source": "curve25519-dalek/src/edwards/affine.rs",
    "rust_name":
    "curve25519_dalek::edwards::affine::{subtle::ConditionallySelectable for curve25519_dalek::edwards::affine::AffinePoint}::conditional_select",
@@ -6807,10 +6807,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem ct_eq_spec (self other : AffinePoint) :\n  ct_eq self other ⦃ c =>\n  (c = Choice.one ↔\n    (Field51_as_Nat self.x) ≡ (Field51_as_Nat other.x) [MOD p] ∧\n    (Field51_as_Nat self.y) ≡ (Field51_as_Nat other.y) [MOD p]) ∧\n  (self.IsValid → other.IsValid → (c = Choice.one ↔ self.toPoint = other.toPoint)) ⦄ := by ...",
+   "theorem ct_eq_spec (self other : AffinePoint) :\n    ct_eq self other ⦃ (c : subtle.Choice) =>\n      (c = Choice.one ↔\n        (Field51_as_Nat self.x) ≡ (Field51_as_Nat other.x) [MOD p] ∧\n        (Field51_as_Nat self.y) ≡ (Field51_as_Nat other.y) [MOD p]) ∧\n      (self.IsValid → other.IsValid →\n        (c = Choice.one ↔ self.toPoint = other.toPoint)) ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/CtEq.lean",
    "spec_docstring":
-   "/-- **Spec and proof** concerning:\n`edwards.affine.AffinePoint.Insts.SubtleConstantTimeEq.ct_eq`:\n- No panic (always returns successfully)\n- The result is Choice.one (true) if and only if the two points are equal (mod p) in coordinates\n- When both points are valid, this is equivalent to toPoint equality\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::ct_eq`**\n• The operation never panics (always returns successfully)\n• Returns `Choice.one` iff `self.x ≡ other.x (mod p)` and `self.y ≡ other.y (mod p)`\n• When both points are valid, this is equivalent to `toPoint` equality\n-/",
    "source": "curve25519-dalek/src/edwards/affine.rs",
    "rust_name":
    "curve25519_dalek::edwards::affine::{subtle::ConstantTimeEq for curve25519_dalek::edwards::affine::AffinePoint}::ct_eq",
@@ -6850,11 +6850,11 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem compress_spec (self : AffinePoint) (hself : self.IsValid) :\n    compress self ⦃ result =>\n    U8x32_as_Nat result = compress_edwards_pure (self.toPoint) ⦄ := by ...",
+   "theorem compress_spec (self : AffinePoint) (hself : self.IsValid) :\n    compress self ⦃ (result : edwards.CompressedEdwardsY) =>\n      U8x32_as_Nat result = compress_edwards_pure (self.toPoint) ⦄ := by ...",
    "spec_file":
    "Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/Compress.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.affine.AffinePoint.compress`**:\n- Requires: the AffinePoint is valid (limbs < 2^54, on curve)\n- Ensures: the compressed bytes equal the pure mathematical compression of the point\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::compress`**\n• The function always succeeds (no panic) when the `AffinePoint` is valid\n• The encoded byte array represents the canonical y-coordinate of `self` in\n  its lower 255 bits, with the parity (sign) bit of x stored in bit 255\n-/",
    "source": "curve25519-dalek/src/edwards/affine.rs",
    "rust_name":
    "curve25519_dalek::edwards::affine::{curve25519_dalek::edwards::affine::AffinePoint}::compress",
@@ -6873,11 +6873,11 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem to_edwards_spec (self : AffinePoint) (hself : self.IsValid)\n  (hx53 : ∀ i < 5, self.x[i]!.val < 2 ^ 53)\n  (hy53 : ∀ i < 5, self.y[i]!.val < 2 ^ 53) :\n    to_edwards self ⦃ result =>\n      result.X = self.x ∧\n      result.Y = self.y ∧\n      result.IsValid ∧\n      result.toPoint = self.toPoint ⦄ := by ...",
+   "theorem to_edwards_spec (self : AffinePoint) (hself : self.IsValid)\n    (hx53 : ∀ i < 5, self.x[i]!.val < 2 ^ 53)\n    (hy53 : ∀ i < 5, self.y[i]!.val < 2 ^ 53) :\n    to_edwards self ⦃ (result : EdwardsPoint) =>\n      result.X = self.x ∧\n      result.Y = self.y ∧\n      result.IsValid ∧\n      result.toPoint = self.toPoint ⦄ := by ...",
    "spec_file":
    "Curve25519Dalek/Specs/Edwards/Affine/AffinePoint/ToEdwards.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.affine.AffinePoint.to_edwards`**:\n- No panic when `self` is a valid AffinePoint and its limbs are < 2^53\n- Structural: `result.X = self.x` and `result.Y = self.y` (direct Rust copies)\n- The resulting EdwardsPoint is valid: `result.IsValid`\n- Math bridge: `result.toPoint = self.toPoint` (same curve point in `Point Ed25519`)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::affine::AffinePoint::to_edwards`**\n• No panic when `self` is a valid AffinePoint and its limbs are < 2^53\n• `result.X = self.x` (direct Rust copy of the affine `x` coordinate)\n• `result.Y = self.y` (direct Rust copy of the affine `y` coordinate)\n• The resulting EdwardsPoint is valid: `result.IsValid`\n• Math bridge: `result.toPoint = self.toPoint` (same curve point in `Point Ed25519`)\n-/",
    "source": "curve25519-dalek/src/edwards/affine.rs",
    "rust_name":
    "curve25519_dalek::edwards::affine::{curve25519_dalek::edwards::affine::AffinePoint}::to_edwards",


### PR DESCRIPTION
This PR systematically streamlines the style, formatting, and code of all 13 spec theorem files in:

- Specs/Edwards/Affine
- Specs/Edwards/CompressedEdwardsY

This PR fixes many small issues, establishing a consistent and clean style.

Frequently made improvements include:

- Adding explicit type annotations to Aeneas result binders: ⦃ result => → ⦃ (result : SomeType) =>
- Name shortenings via removal of redundant prefixes (Std.U8 → U8, scalar.Scalar → Scalar)
- Combining open statements (open A + open B → open A B)
- Merging mathematical information in "natural language description / natural language specs" into module and theorem docstrings
- General docstring improvements
- ...
