### PR TITLE
style: streamline all files in Edwards/EdwardsPoint

### DIFF
--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Add.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Add.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Dablander, Hoang Le Truong
 -/
@@ -8,39 +8,28 @@ import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Edwards.EdwardsPoint.AsProjectiveNiels
 import Curve25519Dalek.Specs.Backend.Serial.CurveModels.CompletedPoint.Add
 import Curve25519Dalek.Specs.Backend.Serial.CurveModels.CompletedPoint.AsExtended
-/-! # Spec Theorems for `EdwardsPoint::add`
 
-Specification and proof for the `add` trait implementations for Edwards points.
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::add`
 
-These functions add two Edwards points via elliptic curve addition using the
-extended twisted Edwards coordinates and the unified addition formulas.
+Add two Edwards points via elliptic curve group addition, returning their sum as an
+EdwardsPoint.
 
-**Source**: curve25519-dalek/src/edwards.rs
+- The core implementation (`&EdwardsPoint + &EdwardsPoint`) takes two EdwardsPoints by
+  reference, converts the right-hand operand to projective niels form, performs the
+  addition in completed point coordinates, and converts the result back to extended
+  twisted Edwards coordinates (Section 3.1 in
+  https://www.iacr.org/archive/asiacrypt2008/53500329/53500329.pdf).
+- The by-value wrapper (`EdwardsPoint + EdwardsPoint`) takes its operands by value and
+  delegates to the core `&EdwardsPoint + &EdwardsPoint` addition.
+
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-/-! ## Core addition: `&EdwardsPoint + &EdwardsPoint` -/
-
 namespace curve25519_dalek.Shared0EdwardsPoint.Insts.CoreOpsArithAddSharedAEdwardsPointEdwardsPoint
 
-/-
-natural language description:
-
-• Takes two EdwardsPoints `self` and `other` (by reference)
-• Returns their sum as an EdwardsPoint via elliptic curve group addition
-• Implementation: converts `other` to projective niels form, performs addition
-  in completed point coordinates, and converts the result back to extended coordinates
-  (Section 3.1 in https://www.iacr.org/archive/asiacrypt2008/53500329/53500329.pdf)
-
-natural language specs:
-
-• The function always succeeds (no panic) for valid input Edwards points
-• The result is a valid Edwards point
-• The result represents the sum of the inputs (in the context of elliptic curve addition)
--/
-
-/-- **Spec and proof** concerning:
-`Shared0EdwardsPoint.Insts.CoreOpsArithAddSharedAEdwardsPointEdwardsPoint.add`:
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::add`**
 • The function always succeeds (no panic) for valid inputs
 • The result is a valid Edwards point
 • The result represents the sum of the inputs (in the context of elliptic curve addition)
@@ -58,33 +47,19 @@ theorem add_spec
 
 end curve25519_dalek.Shared0EdwardsPoint.Insts.CoreOpsArithAddSharedAEdwardsPointEdwardsPoint
 
-/-! ## Wrapper: `EdwardsPoint + EdwardsPoint` -/
-
 namespace curve25519_dalek.edwards.EdwardsPoint.Insts.CoreOpsArithAddEdwardsPointEdwardsPoint
 
-/-
-natural language description:
-
-• Takes two EdwardsPoints `self` and `other`
-• Returns their sum as an EdwardsPoint via elliptic curve group addition
-• Implementation: delegates to the core `&EdwardsPoint + &EdwardsPoint` addition
-
-natural language specs:
-
-• The function always succeeds (no panic) for valid input Edwards points
-• The result is a valid Edwards point
-• The result represents the sum of the inputs (in the context of elliptic curve addition)
--/
-
-/-- **Spec and proof concerning `edwards.AddEdwardsPointEdwardsPointEdwardsPoint.add`**:
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::add`**
 • The function always succeeds (no panic) for valid inputs
 • The result is a valid Edwards point
 • The result represents the sum of the inputs (in the context of elliptic curve addition)
 -/
 @[step]
-theorem add_spec (self other : EdwardsPoint)
-    (h_self_valid : self.IsValid) (h_other_valid : other.IsValid) :
-    add self other ⦃ result =>
+theorem add_spec
+    (self other : EdwardsPoint)
+    (h_self_valid : self.IsValid)
+    (h_other_valid : other.IsValid) :
+    add self other ⦃ (result : EdwardsPoint) =>
       result.IsValid ∧
       result.toPoint = self.toPoint + other.toPoint ⦄ := by
   unfold add

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/AsAffineNiels.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/AsAffineNiels.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
@@ -14,19 +14,14 @@ import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Sub
 import Curve25519Dalek.Specs.Backend.Serial.U64.Constants.EdwardsD2
 import Curve25519Dalek.Aux
 
-/-! # Spec Theorem for `EdwardsPoint::as_affine_niels`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::as_affine_niels`
 
-Specification and proof for `EdwardsPoint::as_affine_niels`.
-
-This function converts an EdwardsPoint from extended twisted Edwards
-coordinates (X, Y, Z, T) to an AffineNielsPoint (y_plus_x, y_minus_x, xy2d)
-by first dehomogenizing (dividing by Z) to obtain the affine coordinates,
-and then computing the affine Niels representation optimized for mixed addition.
-
-Given an EdwardsPoint P = (X:Y:Z:T) in extended ℙ³ coordinates
-(with X/Z = x, Y/Z = y, and T = XY/Z), it computes an
-AffineNielsPoint N = (y_plus_x, y_minus_x, xy2d) corresponding to the
-same curve point in affine Niels form.
+This function converts an EdwardsPoint from extended twisted Edwards coordinates
+(X, Y, Z, T) to an AffineNielsPoint (y_plus_x, y_minus_x, xy2d) by first
+dehomogenizing (dividing by Z) to obtain the affine coordinates, and then
+computing the affine Niels representation optimized for mixed addition.
+Arithmetic is performed in the field 𝔽_p where p = 2^255 − 19.
 
 The concrete formulas are:
 - recip      = Z⁻¹
@@ -36,40 +31,15 @@ The concrete formulas are:
 - y_minus_x  = y − x
 - xy2d       = x · y · 2d
 
-**Source**: curve25519-dalek/src/edwards.rs, lines 543:4-553:5
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
-open Aeneas Aeneas.Std Result Aeneas.Std.WP curve25519_dalek.backend.serial.u64.field.FieldElement51
+open Aeneas Aeneas.Std Result Aeneas.Std.WP
+open curve25519_dalek.backend.serial.u64.field.FieldElement51
   curve25519_dalek.backend.serial.u64.constants
-open curve25519_dalek.backend.serial.curve_models.AffineNielsPoint
-open curve25519_dalek.montgomery
+  curve25519_dalek.backend.serial.curve_models.AffineNielsPoint
+  curve25519_dalek.montgomery
 namespace curve25519_dalek.edwards.EdwardsPoint
-
-/-
-natural language description:
-
-• Takes an EdwardsPoint (X, Y, Z, T) in extended coordinates and computes
-  an AffineNielsPoint (y_plus_x, y_minus_x, xy2d) representing the same
-  curve point in affine Niels form. Arithmetic is performed in the
-  field 𝔽_p where p = 2^255 - 19.
-
-natural language specs:
-
-• The function always succeeds (no panic)
-• Given input P = (X, Y, Z, T) with Z ≢ 0 (mod p), the output
-  N = (y_plus_x, y_minus_x, xy2d) satisfies modulo p:
-  - y_plus_x · Z ≡ Y + X (mod p)
-  - y_minus_x · Z + X ≡ Y (mod p)
-  - xy2d · Z² ≡ X · Y · (2 · d) (mod p)
-• Output bounds:
-  - y_plus_x: all limbs < 2^54
-  - y_minus_x: all limbs < 2^52
-  - xy2d: all limbs < 2^52
--/
-
--- ========================================================================
--- Helper lemma: bridge from toField ≠ 0 to Field51_as_Nat % p ≠ 0
--- ========================================================================
 
 private lemma field51_modP_ne_zero_of_toField_ne_zero
     (fe : backend.serial.u64.field.FieldElement51)
@@ -77,12 +47,8 @@ private lemma field51_modP_ne_zero_of_toField_ne_zero
     Field51_as_Nat fe % p ≠ 0 := by
   intro hmod
   apply h
-  unfold curve25519_dalek.backend.serial.u64.field.FieldElement51.toField
+  unfold toField
   exact Edwards.lift_mod_eq (Field51_as_Nat fe) 0 (by simpa [Nat.zero_mod] using hmod)
-
--- ========================================================================
--- Helper lemmas for modular arithmetic reasoning
--- ========================================================================
 
 /-- y_plus_x modular arithmetic: `(y + x) * Z ≡ Y + X` from
     `y * Z ≡ Y` and `x * Z ≡ X`. -/
@@ -130,50 +96,32 @@ private lemma xy2d_mod_arith (xy2d_nat fe_nat d2_nat x_nat y_nat Z_nat X_nat Y_n
     _ ≡ X_nat * Y_nat * (2 * d) [MOD p] :=
         Nat.ModEq.mul_right _ (Nat.ModEq.mul h_xZ h_yZ)
 
--- ========================================================================
--- Main spec theorem
--- ========================================================================
-
-
-/-- **Spec and proof concerning `edwards.EdwardsPoint.as_affine_niels`**:
-- No panic (always returns successfully)
-- Given input:
-  • an EdwardsPoint `self` satisfying `self.IsValid`
-    (coordinates X, Y, Z, T with limbs < 2^53, Z ≠ 0 in the field,
-    extended coordinate relation XY = TZ, and the curve equation),
-the output AffineNielsPoint (y_plus_x, y_minus_x, xy2d) computed by
-`as_affine_niels self` satisfies modulo p:
-- y_plus_x · Z ≡ Y + X (mod p)
-- y_minus_x · Z + X ≡ Y (mod p)
-- xy2d · Z² ≡ X · Y · (2 · d) (mod p)
-where p = 2^255 - 19.
-
-These are the standard affine Niels conversion formulas obtained by dehomogenizing
-the extended coordinates and computing y ± x and 2dxy.
-
-Output bounds (from field element arithmetic):
-- y_plus_x: all limbs < 2^54
-- y_minus_x: all limbs < 2^52
-- xy2d: all limbs < 2^52
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::as_affine_niels`**
+• The function always succeeds (no panic) for valid input EdwardsPoints
+• `y_plus_x · Z ≡ Y + X` (mod p)
+• `y_minus_x · Z + X ≡ Y` (mod p)
+• `xy2d · Z² ≡ X · Y · (2 · d)` (mod p)
+• `y_plus_x`: all limbs < 2^54
+• `y_minus_x`: all limbs < 2^52
+• `xy2d`: all limbs < 2^52
 -/
 @[step]
 theorem as_affine_niels_spec
-  (self : EdwardsPoint)
-  (hself : self.IsValid) :
-  as_affine_niels self ⦃ an =>
-  let X := Field51_as_Nat self.X
-  let Y := Field51_as_Nat self.Y
-  let Z := Field51_as_Nat self.Z
-  let ypx := Field51_as_Nat an.y_plus_x
-  let ymx := Field51_as_Nat an.y_minus_x
-  let xy2d_val := Field51_as_Nat an.xy2d
-  (ypx * Z) % p = (Y + X) % p ∧
-  (ymx * Z + X) % p = Y % p ∧
-  (xy2d_val * Z * Z) % p = (X * Y * (2 * d)) % p ∧
-  (∀ i < 5, an.y_plus_x[i]!.val < 2 ^ 54) ∧
-  (∀ i < 5, an.y_minus_x[i]!.val < 2 ^ 52) ∧
-  (∀ i < 5, an.xy2d[i]!.val < 2 ^ 52) ⦄
-:= by
+    (self : EdwardsPoint)
+    (hself : self.IsValid) :
+    as_affine_niels self ⦃ (an : backend.serial.curve_models.AffineNielsPoint) =>
+      let X := Field51_as_Nat self.X
+      let Y := Field51_as_Nat self.Y
+      let Z := Field51_as_Nat self.Z
+      let ypx := Field51_as_Nat an.y_plus_x
+      let ymx := Field51_as_Nat an.y_minus_x
+      let xy2d_val := Field51_as_Nat an.xy2d
+      (ypx * Z) % p = (Y + X) % p ∧
+      (ymx * Z + X) % p = Y % p ∧
+      (xy2d_val * Z * Z) % p = (X * Y * (2 * d)) % p ∧
+      (∀ i < 5, an.y_plus_x[i]!.val < 2 ^ 54) ∧
+      (∀ i < 5, an.y_minus_x[i]!.val < 2 ^ 52) ∧
+      (∀ i < 5, an.xy2d[i]!.val < 2 ^ 52) ⦄ := by
   have h_X_bounds := hself.X_bounds
   have h_Y_bounds := hself.Y_bounds
   have h_Z_bounds := hself.Z_bounds

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/AsProjective.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/AsProjective.lean
@@ -1,44 +1,34 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Dablander
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 
-/-! # Spec Theorem for `EdwardsPoint::as_projective`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::as_projective`
 
-Specification and proof for `EdwardsPoint::as_projective`.
+Convert an EdwardsPoint from extended twisted Edwards coordinates `(X, Y, Z, T)` to
+projective coordinates `(X, Y, Z)` by dropping the auxiliary coordinate `T`.
 
-This function converts to projective coordinates.
-
-**Source**: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.edwards.EdwardsPoint
 
-/-
-natural language description:
-
-• Converts an EdwardsPoint from extended twisted Edwards coordinates (X, Y, Z, T)
-to projective coordinates (X, Y, Z)
-
-natural language specs:
-
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::as_projective`**
 • The function always succeeds (no panic)
-• The resulting ProjectivePoint has the same X, Y, Z coordinates as the input EdwardsPoint
--/
-
-/-- **Spec and proof concerning `edwards.EdwardsPoint.as_projective`**:
-- No panic (always returns successfully)
-- The resulting ProjectivePoint coordinates match the EdwardsPoint coordinates (X, Y, Z)
+• The resulting `ProjectivePoint` has the same `X`, `Y`, `Z` coordinates as the input
 -/
 @[step]
-theorem as_projective_spec (e : EdwardsPoint) :
-    edwards.EdwardsPoint.as_projective e ⦃ q =>
-    q.X = e.X ∧ q.Y = e.Y ∧ q.Z = e.Z ⦄ := by
-  unfold edwards.EdwardsPoint.as_projective
+theorem as_projective_spec (self : EdwardsPoint) :
+    as_projective self ⦃ (result : backend.serial.curve_models.ProjectivePoint) =>
+      result.X = self.X ∧
+      result.Y = self.Y ∧
+      result.Z = self.Z ⦄ := by
+  unfold as_projective
   simp
 
 end curve25519_dalek.edwards.EdwardsPoint

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/AsProjectiveNiels.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/AsProjectiveNiels.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Dablander, Alessandro D'Angelo, Hoang Le Truong
 -/
@@ -14,60 +14,46 @@ import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Sub
 import Curve25519Dalek.Specs.Backend.Serial.U64.Constants.EdwardsD2
 import Curve25519Dalek.Aux
 
-/-! # Spec Theorem for `EdwardsPoint::as_projective_niels`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::as_projective_niels`
 
-Specification and proof for `EdwardsPoint::as_projective_niels`.
+Convert an EdwardsPoint from extended twisted Edwards coordinates `(X, Y, Z, T)` to
+ProjectiveNiels coordinates `(A, B, Z', C)`, a representation optimized for point
+addition operations. Working modulo `p = 2^255 - 19`, the formulas are:
+- `A ≡ Y + X (mod p)`
+- `B ≡ Y - X (mod p)`
+- `Z' = Z` (unchanged)
+- `C ≡ T · 2 · d (mod p)`
 
-This function converts an EdwardsPoint to a ProjectiveNielsPoint, which is a
-representation optimized for point addition operations.
-
-Source: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
-open Aeneas Aeneas.Std Result Aeneas.Std.WP curve25519_dalek.backend.serial.u64.field.FieldElement51
+open Aeneas Aeneas.Std Result Aeneas.Std.WP
+open curve25519_dalek.backend.serial.u64.field.FieldElement51
   curve25519_dalek.backend.serial.u64.constants
-open curve25519_dalek.backend.serial.curve_models.ProjectiveNielsPoint
-open curve25519_dalek.montgomery
+  curve25519_dalek.backend.serial.curve_models.ProjectiveNielsPoint
+  curve25519_dalek.montgomery
 namespace curve25519_dalek.edwards.EdwardsPoint
 
-/-
-natural language description:
-
-• Converts an EdwardsPoint from extended twisted Edwards coordinates (X, Y, Z, T)
-to ProjectiveNiels coordinates (A, B, Z', C), where:
-  - A ≡ Y + X (mod p)
-  - B ≡ Y - X (mod p)
-  - Z' = Z (unchanged)
-  - C ≡ T * 2 * d (mod p)
-
-natural language specs:
-
-• The function always succeeds (no panic)
-• For the input Edwards point (X, Y, Z, T), the resulting ProjectiveNielsPoint has coordinates:
-  - A ≡ Y + X (mod p)
-  - B ≡ Y - X (mod p)
-  - Z' = Z
-  - C ≡ T * 2 * d (mod p)
-where p = 2^255 - 19
--/
-
-/-- **Spec and proof concerning `edwards.EdwardsPoint.as_projective_niels`**:
-- No panic (always returns successfully)
-- For the input Edwards point (X, Y, Z, T), the resulting ProjectiveNielsPoint has coordinates:
-  - A ≡ Y + X (mod p)
-  - B ≡ Y - X (mod p)
-  - Z' = Z
-  - C ≡ T * 2 * d (mod p)
-where p = 2^255 - 19
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::as_projective_niels`**
+• The function always succeeds (no panic) for valid input EdwardsPoints
+• The resulting `Y_plus_X` limb representation `A` satisfies `A ≡ Y + X (mod p)`
+• The resulting `Y_minus_X` limb representation `B` satisfies `B + X ≡ Y (mod p)`
+• The resulting `Z` limb representation `Z'` satisfies `Z' ≡ Z (mod p)`
+• The resulting `T2d` limb representation `C` satisfies `C ≡ T · (2 · d) (mod p)`
+• Limb bounds: `Y_plus_X` < 2^54, `Y_minus_X` < 2^52, `Z` < 2^53, `T2d` < 2^52
+• The result is a valid `ProjectiveNielsPoint`
+• The result represents the same elliptic curve point as the input
 -/
 @[step]
-theorem as_projective_niels_spec (e : EdwardsPoint)
-    (he : e.IsValid) :
-    as_projective_niels e ⦃ (pn : backend.serial.curve_models.ProjectiveNielsPoint) =>
-      let X := Field51_as_Nat e.X
-      let Y := Field51_as_Nat e.Y
-      let Z := Field51_as_Nat e.Z
-      let T := Field51_as_Nat e.T
+theorem as_projective_niels_spec
+    (self : EdwardsPoint)
+    (hself : self.IsValid) :
+    as_projective_niels self ⦃ (pn : backend.serial.curve_models.ProjectiveNielsPoint) =>
+      let X := Field51_as_Nat self.X
+      let Y := Field51_as_Nat self.Y
+      let Z := Field51_as_Nat self.Z
+      let T := Field51_as_Nat self.T
       let A := Field51_as_Nat pn.Y_plus_X
       let B := Field51_as_Nat pn.Y_minus_X
       let Z' := Field51_as_Nat pn.Z
@@ -81,66 +67,62 @@ theorem as_projective_niels_spec (e : EdwardsPoint)
       ∀ i < 5, (pn.Z[i]!).val < 2 ^ 53 ∧
       ∀ i < 5, (pn.T2d[i]!).val < 2 ^ 52) ∧
       pn.IsValid ∧
-      e.toPoint = pn.toPoint
-       ⦄ := by
+      self.toPoint = pn.toPoint ⦄ := by
   unfold as_projective_niels
   step*
-  · exact he.Y_bounds
-  · have:= he.X_bounds
+  · exact hself.Y_bounds
+  · have := hself.X_bounds
     exact this
-  · have:= he.T_bounds
+  · have := hself.T_bounds
     grind
   · refine ⟨?_, ?_, ?_, ?_⟩
-    · congr 1; exact pointwise_add_Field51_as_Nat e.Y e.X fe fe_post1
+    · congr 1; exact pointwise_add_Field51_as_Nat self.Y self.X fe fe_post1
     · assumption
     · simp_all [Nat.ModEq]
     · constructor
-      · have := he.Z_bounds
+      · have := hself.Z_bounds
         simp_all
-      · have := pointwise_add_Field51_as_Nat e.Y e.X fe fe_post1
-        rw[← Nat.ModEq,Montgomery.lift_mod_eq_iff] at fe1_post2
+      · have := pointwise_add_Field51_as_Nat self.Y self.X fe fe_post1
+        rw [← Nat.ModEq, Montgomery.lift_mod_eq_iff] at fe1_post2
         have : (Field51_as_Nat fe1) =
-            (Field51_as_Nat e.Y) - ((Field51_as_Nat e.X) : Edwards.CurveField) := by grind
-        rw[Montgomery.lift_mod_eq_iff] at fe3_post1
-        have : ({ Y_plus_X := fe, Y_minus_X := fe1, Z := e.Z, T2d := fe3 } :
+            (Field51_as_Nat self.Y) - ((Field51_as_Nat self.X) : Edwards.CurveField) := by grind
+        rw [Montgomery.lift_mod_eq_iff] at fe3_post1
+        have : ({ Y_plus_X := fe, Y_minus_X := fe1, Z := self.Z, T2d := fe3 } :
             backend.serial.curve_models.ProjectiveNielsPoint).IsValid := by
           refine
             { Z_ne_zero := ?_, T2d_relation := ?_, on_curve := ?_,
               Y_plus_X_bounds := ?_, Y_minus_X_bounds := ?_,
               Z_bounds := ?_, T2d_bounds := ?_ }
-          · have := he.Z_ne_zero
+          · have := hself.Z_ne_zero
             simp_all
           · unfold toField
-            simp_all
-            have := he.T_relation
-            simp only  at this
+            simp_all only
+            have := hself.T_relation
+            simp only at this
             unfold toField at this
             ring_nf
-            have:Edwards.Ed25519.d=d:=rfl
+            have : Edwards.Ed25519.d = d := rfl
             grind
           · unfold toField
-            simp_all
-            have := he.on_curve
+            simp_all only
+            have := hself.on_curve
             simp only at this
             unfold toField at this
             grind
           · simp_all  -- Y_plus_X_bounds: < 2^54
           · -- Y_minus_X_bounds: goal < 2^54, fact fe1_post1 : < 2^52
             intro i hi; have := fe1_post1 i hi; agrind
-          · have := he.Z_bounds
+          · have := hself.Z_bounds
             simp_all
           · -- T2d_bounds: < 2^52
             intro i hi; have := fe3_post2 i hi; agrind
         simp only [this, true_and]
-        unfold toPoint curve25519_dalek.backend.serial.curve_models.ProjectiveNielsPoint.toPoint
-        simp only [he, ↓reduceDIte, this]
+        unfold toPoint backend.serial.curve_models.ProjectiveNielsPoint.toPoint
+        simp only [hself, ↓reduceDIte, this]
         unfold toPoint'
-          curve25519_dalek.backend.serial.curve_models.ProjectiveNielsPoint.toPoint' toField
-        simp_all only [Array.getElem!_Nat_eq, List.Vector.length_val,
-          UScalar.ofNatCore_val_eq, getElem!_pos, Nat.reducePow, Nat.cast_add,
-          sub_add_cancel, Nat.cast_mul, ZMod.natCast_mod, Nat.cast_ofNat,
-          add_sub_sub_cancel, add_add_sub_cancel, Edwards.Point.mk.injEq]
-        have := he.Z_ne_zero
+          backend.serial.curve_models.ProjectiveNielsPoint.toPoint' toField
+        simp_all only
+        have := hself.Z_ne_zero
         unfold toField at this
         field_simp
         grind

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Compress.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Compress.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus Dablander
+Authors: Markus Dablander, Alessandro D'Angelo
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
@@ -10,9 +10,8 @@ import Curve25519Dalek.ExternallyVerified
 import Curve25519Dalek.Specs.Edwards.EdwardsPoint.ToAffine
 import Curve25519Dalek.Specs.Edwards.Affine.AffinePoint.Compress
 
-/-! # Spec Theorem for `EdwardsPoint::compress`
-
-Specification for `EdwardsPoint::compress`.
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::compress`
 
 Converts an EdwardsPoint in extended twisted Edwards coordinates to a compressed
 32-byte representation. The implementation first converts to affine (x, y) = (X/Z, Y/Z),
@@ -21,40 +20,21 @@ byte 31 (via XOR). The y-coordinate and the x parity are sufficient to reconstru
 the full point given the defining equation -x² + y² = 1 + dx²y² of the Edwards curve,
 which is quadratic in x.
 
-**Source**: curve25519-dalek/src/edwards.rs, lines 1662-1790
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.math
-
 namespace curve25519_dalek.edwards.EdwardsPoint
 
-/-
-Natural language description:
-
-    • Compresses an EdwardsPoint (X:Y:Z:T) to a CompressedEdwardsY (U8x32 byte array)
-    • First converts the point from projective to affine coordinates:
-        x = X · Z⁻¹,  y = Y · Z⁻¹
-    • Then serializes y as a 32-byte little-endian array and stores the sign
-      (parity) of x in the high bit of byte 31 via XOR
-
-Natural language specs:
-
-    • The function always succeeds (no panic) when `self.IsValid`
-    • On success, the byte encoding equals `compress_edwards_pure self.toPoint`:
-      - Bytes 0-30 and the low 7 bits of byte 31 encode the canonical y-coordinate
-      - The high bit of byte 31 encodes the parity (sign) of the x-coordinate
--/
-
-/-- **Spec and proof concerning `edwards.EdwardsPoint.compress`**:
-- Requires `self.IsValid` (limbs < 2^53, Z ≠ 0, extended relation, curve equation).
-- Ensures the compressed bytes equal the pure mathematical compression of the
-  corresponding abstract point:
-  `U8x32_as_Nat result = compress_edwards_pure self.toPoint`.
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::compress`**
+• The function always succeeds (no panic) when `self.IsValid`
+• The byte encoding of the result equals the pure mathematical compression of the
+  corresponding abstract point: `U8x32_as_Nat result = compress_edwards_pure self.toPoint`
 -/
 @[step]
 theorem compress_spec (self : EdwardsPoint) (hself : self.IsValid) :
-    compress self ⦃ result =>
+    compress self ⦃ (result : CompressedEdwardsY) =>
       U8x32_as_Nat result = compress_edwards_pure self.toPoint ⦄ := by
   unfold compress
   let* ⟨ap, h_valid, h_point⟩ ← to_affine_spec _ hself

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/ConditionalSelect.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/ConditionalSelect.lean
@@ -1,49 +1,30 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Dablander
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ConditionalSelect
 
-/-! # Spec Theorem for `EdwardsPoint::conditional_select`
-
-Specification and proof for the `ConditionallySelectable` trait implementation for `EdwardsPoint`.
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::conditional_select`
 
 This function conditionally selects between two Edwards points based on a `Choice` value
-by applying `FieldElement51::conditional_select` component-wise to the coordinates (X, Y, Z, T).
+by applying `FieldElement51::conditional_select` component-wise to the coordinates (X, Y, Z, T)
+in constant time.
 
-Returns `b` when `choice = 1` and `a` when `choice = 0`, in constant time.
-
-**Source**: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.edwards.EdwardsPoint.Insts.SubtleConditionallySelectable
 
-/-
-natural language description:
-
-- Takes two EdwardsPoints `a` and `b` and a `Choice` value
-- Returns one of the two points based on the choice, in constant time
-- Implementation: applies `FieldElement51::conditional_select` component-wise
-  to the coordinates (X, Y, Z, T)
-
-natural language specs:
-
-- The function always succeeds (no panic)
-- Returns `b` when `choice = 1` and `a` when `choice = 0`
--/
-
-/--
-**Spec and proof concerning `edwards.EdwardsPoint.Insts.SubtleConditionallySelectable.conditional_select`**:
-- No panic (always returns successfully)
-- Returns `b` when `choice = 1` and `a` when `choice = 0`
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::conditional_select`**
+• No panic (always returns successfully)
+• Returns `b` when `choice = 1` and `a` when `choice = 0`
 -/
 @[step]
-theorem conditional_select_spec
-    (a b : EdwardsPoint)
-    (choice : subtle.Choice) :
+theorem conditional_select_spec (a b : EdwardsPoint) (choice : subtle.Choice) :
     conditional_select a b choice ⦃ (result : EdwardsPoint) =>
       result = if choice.val = 1#u8 then b else a ⦄ := by
   unfold conditional_select

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/CtEq.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/CtEq.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus Dablander, Hoang Le Truong
+Authors: Markus Dablander, Alessandro D'Angelo, Hoang Le Truong
 -/
 import Curve25519Dalek.Aux
 import Curve25519Dalek.Funs
@@ -12,62 +12,48 @@ import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.CtEq
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ToBytes
 import Curve25519Dalek.Specs.Field.FieldElement51.IsZero
-
 import Mathlib.Data.Nat.ModEq
 
-/-! # Spec Theorem for `EdwardsPoint::ct_eq`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::ct_eq`
 
-Specification and proof for `EdwardsPoint::ct_eq`.
+Performs a constant-time equality comparison between two `EdwardsPoint` values:
 
-This function performs constant-time equality comparison for Edwards points.
+• Determines whether two `EdwardsPoint`s represent the same curve point.
+• Checks equality of affine coordinates `(x, y) = (X/Z, Y/Z)` and
+  `(x', y') = (X'/Z', Y'/Z')` without converting to affine form, by comparing
+  `(X·Z', Y·Z')` against `(X'·Z, Y'·Z)`.
+• Runs in constant time independent of the inputs in order to avoid
+  timing-side-channel vulnerabilities.
 
-**Source**: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.u64.field.FieldElement51
-
 namespace curve25519_dalek.edwards.EdwardsPoint.Insts.SubtleConstantTimeEq
 
-/-
-Natural language description:
-
-    • Compares two EdwardsPoint types to determine whether they represent the same point
-
-    • Checks equality of affine coordinates (x,y) = (X/Z, Y/Z) and (x',y') = (X'/Z', Y'/Z') without
-      actually converting to affine coordinates by comparing (X·Z', Y·Z') with (X'·Z, Y'·Z)
-
-    • Crucially does so in constant time irrespective of the inputs to avoid security liabilities
-
-Natural language specs:
-
-    • Requires: Z coordinates must be non-zero mod p (maintained as invariant
-      for valid EdwardsPoints)
-    • (e1.X · e2.Z, e1.Y · e2.Z) = (e2.X · e1.Z, e2.Y · e1.Z) ⟺ Choice = True
--/
-
-/-- **Spec and proof concerning `edwards.ConstantTimeEqEdwardsPoint.ct_eq`**:
-- No panic (always returns successfully)
-- The result is `Choice.one` (true) iff the two points are equal (mod p) in
-  affine coordinates
-- When both points are valid, this is equivalent to `toPoint` equality
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::ct_eq`**
+• No panic (always returns successfully)
+• The result is `Choice.one` iff the cross-multiplied projective coordinates
+  agree mod p: `X·Z' ≡ X'·Z` and `Y·Z' ≡ Y'·Z` (mod p)
+• When both points are valid, this is equivalent to `toPoint` equality
 -/
 @[step]
-theorem ct_eq_spec (e1 e2 : EdwardsPoint)
-  -- Bounds are needed for the internal field multiplications
-  (h_e1_X : ∀ i, i < 5 → e1.X.val[i]!.val ≤ 2 ^ 53)
-  (h_e1_Y : ∀ i, i < 5 → e1.Y.val[i]!.val ≤ 2 ^ 53)
-  (h_e1_Z : ∀ i, i < 5 → e1.Z.val[i]!.val ≤ 2 ^ 53)
-  (h_e2_X : ∀ i, i < 5 → e2.X.val[i]!.val ≤ 2 ^ 53)
-  (h_e2_Y : ∀ i, i < 5 → e2.Y.val[i]!.val ≤ 2 ^ 53)
-  (h_e2_Z : ∀ i, i < 5 → e2.Z.val[i]!.val ≤ 2 ^ 53) :
-  ct_eq e1 e2 ⦃ c =>
-  (c = Choice.one ↔
-    (Field51_as_Nat e1.X * Field51_as_Nat e2.Z)
-      ≡ (Field51_as_Nat e2.X * Field51_as_Nat e1.Z) [MOD p] ∧
-    (Field51_as_Nat e1.Y * Field51_as_Nat e2.Z)
-      ≡ (Field51_as_Nat e2.Y * Field51_as_Nat e1.Z) [MOD p]) ∧
-  (e1.IsValid → e2.IsValid → (c = Choice.one ↔ e1.toPoint = e2.toPoint)) ⦄ := by
+theorem ct_eq_spec (self other : EdwardsPoint)
+    (h_self_X : ∀ i, i < 5 → self.X.val[i]!.val ≤ 2 ^ 53)
+    (h_self_Y : ∀ i, i < 5 → self.Y.val[i]!.val ≤ 2 ^ 53)
+    (h_self_Z : ∀ i, i < 5 → self.Z.val[i]!.val ≤ 2 ^ 53)
+    (h_other_X : ∀ i, i < 5 → other.X.val[i]!.val ≤ 2 ^ 53)
+    (h_other_Y : ∀ i, i < 5 → other.Y.val[i]!.val ≤ 2 ^ 53)
+    (h_other_Z : ∀ i, i < 5 → other.Z.val[i]!.val ≤ 2 ^ 53) :
+    ct_eq self other ⦃ (c : subtle.Choice) =>
+      (c = Choice.one ↔
+        (Field51_as_Nat self.X * Field51_as_Nat other.Z)
+          ≡ (Field51_as_Nat other.X * Field51_as_Nat self.Z) [MOD p] ∧
+        (Field51_as_Nat self.Y * Field51_as_Nat other.Z)
+          ≡ (Field51_as_Nat other.Y * Field51_as_Nat self.Z) [MOD p]) ∧
+      (self.IsValid → other.IsValid → (c = Choice.one ↔ self.toPoint = other.toPoint)) ⦄ := by
   unfold ct_eq
   step as ⟨h1, h2⟩
   step as ⟨h3, h4⟩
@@ -97,7 +83,8 @@ theorem ct_eq_spec (e1 e2 : EdwardsPoint)
         rw [h_x_canon, h_y_canon]; exact h_mod_eq
       apply U8x32_as_Nat_injective; exact h_nat_eq
   rw [to_bytes_iff_mod h1 h3, to_bytes_iff_mod h7 h9]; dsimp only [Nat.ModEq] at *
-  refine ⟨⟨fun ⟨hx, hy⟩ ↦ ⟨?_, ?_⟩, fun ⟨hx, hy⟩ ↦ ⟨?_, ?_⟩⟩, fun hv1 hv2 => ?_⟩
+  refine ⟨⟨fun ⟨hx, hy⟩ ↦ ⟨?_, ?_⟩, fun ⟨hx, hy⟩ ↦ ⟨?_, ?_⟩⟩,
+    fun hv1 hv2 => ?_⟩
   · -- Forward X: h1=h3 -> SpecL=SpecR
     exact Nat.ModEq.trans (Nat.ModEq.trans (Nat.ModEq.symm h2) hx) h4
   · -- Forward Y: h7=h9 -> SpecL=SpecR
@@ -106,14 +93,14 @@ theorem ct_eq_spec (e1 e2 : EdwardsPoint)
     exact Nat.ModEq.trans (Nat.ModEq.trans h2 hx) (Nat.ModEq.symm h4)
   · -- Backward Y: SpecL=SpecR -> h7=h9
     exact Nat.ModEq.trans (Nat.ModEq.trans h8 hy) (Nat.ModEq.symm h10)
-  · -- toPoint equivalence (given hv1 : e1.IsValid, hv2 : e2.IsValid)
+  · -- toPoint equivalence (given hv1 : self.IsValid, hv2 : other.IsValid)
     -- Bridge: modular cross-multiplication equalities ↔ toPoint equality
     have mod_iff_toPoint :
-        ((Field51_as_Nat e1.X * Field51_as_Nat e2.Z)
-            ≡ (Field51_as_Nat e2.X * Field51_as_Nat e1.Z) [MOD p] ∧
-         (Field51_as_Nat e1.Y * Field51_as_Nat e2.Z)
-            ≡ (Field51_as_Nat e2.Y * Field51_as_Nat e1.Z) [MOD p]) ↔
-        e1.toPoint = e2.toPoint := by
+        ((Field51_as_Nat self.X * Field51_as_Nat other.Z)
+            ≡ (Field51_as_Nat other.X * Field51_as_Nat self.Z) [MOD p] ∧
+         (Field51_as_Nat self.Y * Field51_as_Nat other.Z)
+            ≡ (Field51_as_Nat other.Y * Field51_as_Nat self.Z) [MOD p]) ↔
+        self.toPoint = other.toPoint := by
       simp only [Montgomery.lift_mod_eq_iff, Nat.cast_mul]
       unfold EdwardsPoint.toPoint
       simp only [hv1, ↓reduceDIte, hv2]

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Double.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Double.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus Dablander, Liao Zhang, Filippo A. E. Nuccio
+Authors: Markus Dablander, Liao Zhang, Filippo A. E. Nuccio, Alessandro D'Angelo
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Edwards.Representation
@@ -10,51 +10,51 @@ import Curve25519Dalek.Specs.Edwards.EdwardsPoint.AsProjective
 import Curve25519Dalek.Specs.Backend.Serial.CurveModels.ProjectivePoint.Double
 import Curve25519Dalek.Specs.Backend.Serial.CurveModels.CompletedPoint.AsExtended
 
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::double`
 
-/-! # Spec Theorem for `EdwardsPoint::double`
+Doubles an Edwards point (computes 2P = P + P) using elliptic curve point addition.
 
-Specification and proof for `EdwardsPoint::double`.
-
-This function doubles an Edwards point (adds it to itself) using elliptic curve point addition.
-
-**Source**: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
+open Edwards curve25519_dalek.backend.serial.curve_models
+  curve25519_dalek.backend.serial.curve_models.ProjectivePoint
+  curve25519_dalek.backend.serial.u64.field
 namespace curve25519_dalek.edwards.EdwardsPoint
-/-new-/
-open Edwards backend.serial.curve_models backend.serial.curve_models.ProjectivePoint
-  backend.serial.u64.field
 
--- The `linear_combination` steps require extra heartbeats
--- for the algebraic verification of the curve equation.
+-- Mark `p` as irreducible locally so that algebraic reasoning about the
+-- curve equation does not unfold the prime modulus.
 attribute [local irreducible] p in
-/-- **Spec and proof concerning
-`edwards.EdwardsPoint.double`**:
-- Returns the doubled point 2P (= P + P in elliptic
-  curve addition) where P is the input EdwardsPoint -/
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::double`**
+• The function always succeeds (no panic) for valid input EdwardsPoints
+• The result is a valid Edwards point
+• The result represents the doubled input point 2P (= P + P) under elliptic curve addition
+-/
 @[step]
-theorem double_spec (e : EdwardsPoint) (he_valid : e.IsValid) :
-    double e ⦃ result =>
-    result.IsValid ∧ result.toPoint = e.toPoint + e.toPoint ⦄ := by
+theorem double_spec (self : EdwardsPoint) (hself : self.IsValid) :
+    double self ⦃ (result : EdwardsPoint) =>
+      result.IsValid ∧
+      result.toPoint = self.toPoint + self.toPoint ⦄ := by
   unfold double
   -- Step 1: as_projective (preserves X, Y, Z)
   apply WP.spec_bind
-    (edwards.EdwardsPoint.as_projective_spec e)
+    (as_projective_spec self)
   intro pp ⟨hpp_X, hpp_Y, hpp_Z⟩
-  -- Build pp.OnCurve from e.IsValid
+  -- Build pp.OnCurve from self.IsValid
   have hpp_on : pp.OnCurve := {
-    Z_ne_zero := by rw [hpp_Z]; exact he_valid.Z_ne_zero
-    on_curve := by rw [hpp_X, hpp_Y, hpp_Z]; exact he_valid.on_curve
+    Z_ne_zero := by rw [hpp_Z]; exact hself.Z_ne_zero
+    on_curve := by rw [hpp_X, hpp_Y, hpp_Z]; exact hself.on_curve
   }
   -- Step 2: double via core theorem (existential form)
   obtain ⟨cp, h_run, h_cp_valid, h_cp_eq⟩ :=
     double_spec_core pp hpp_on
-      (fun i hi => by rw [hpp_X]; exact he_valid.X_bounds i hi)
-      (fun i hi => by rw [hpp_Y]; exact he_valid.Y_bounds i hi)
+      (fun i hi => by rw [hpp_X]; exact hself.X_bounds i hi)
+      (fun i hi => by rw [hpp_Y]; exact hself.Y_bounds i hi)
       (by rw [hpp_Z]
           exact FieldElement51.IsValid_of_lt_pow
-            he_valid.Z_bounds (by decide))
+            hself.Z_bounds (by decide))
   -- Thread pp.double = ok cp through the WP chain
   simp only [h_run]
   -- Step 3: as_extended (preserves the point)
@@ -68,7 +68,7 @@ theorem double_spec (e : EdwardsPoint) (he_valid : e.IsValid) :
     congr 1 <;>
       simp only [ProjectivePoint.toPoint',
         hpp_X, hpp_Y, hpp_Z,
-        EdwardsPoint.toPoint, dif_pos he_valid,
+        EdwardsPoint.toPoint, dif_pos hself,
         EdwardsPoint.toPoint']⟩
 
 end curve25519_dalek.edwards.EdwardsPoint

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Eq.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Eq.lean
@@ -1,61 +1,52 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Edwards.Representation
-import Curve25519Dalek.Specs.Edwards.EdwardsPoint.CtEq
 import Curve25519Dalek.Math.Montgomery.Curve
-/-! # Spec Theorem for `EdwardsPoint::eq`
+import Curve25519Dalek.Specs.Edwards.EdwardsPoint.CtEq
 
-Specification and proof for the `eq` (PartialEq) trait implementation for Edwards points.
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::eq`
 
-This function performs equality comparison for two Edwards points by delegating
-to constant-time equality (`ct_eq`) and converting the resulting `Choice` to `Bool`.
+Performs equality comparison between two `EdwardsPoint` values:
+
+• Takes two `EdwardsPoint`s `self` and `other`.
+• Returns `true` if they represent the same point on the curve, `false` otherwise.
+• Implementation: delegates to constant-time equality (`ct_eq`), which cross-multiplies
+  coordinates (X₁·Z₂ vs X₂·Z₁ and Y₁·Z₂ vs Y₂·Z₁), then converts the resulting
+  `Choice` to `Bool`.
+
 Two extended Edwards points (X₁:Y₁:Z₁:T₁) and (X₂:Y₂:Z₂:T₂) are considered equal
 when they represent the same affine point, i.e., X₁·Z₂ = X₂·Z₁ and Y₁·Z₂ = Y₂·Z₁ (mod p).
 
-**Source**: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.u64.field
-namespace curve25519_dalek.edwards.EdwardsPoint.Insts.CoreCmpPartialEqEdwardsPoint
 
-
+namespace curve25519_dalek
 
 /-- If `c.val = 1`, then `c = Choice.one` (by proof irrelevance on the `valid` field). -/
 @[simp]
 theorem Choice.eq_one (c : subtle.Choice) : c.val = 1#u8 → c = Choice.one := by
-  intro h; cases c; simp_all [Choice.one]
+  intro h; cases c; simp_all only [Choice.one]
 
-/-- If `c.val = 0`, then `c = Choice.zero` (by proof irrelevance on the `valid` field). -/
-@[simp]
-theorem Choice.eq_zero (c : subtle.Choice) : c.val = 0#u8 → c = Choice.zero := by
-  intro h; cases c; simp_all [Choice.zero]
-/-
-natural language description:
+end curve25519_dalek
 
-• Takes two EdwardsPoints `self` and `other`
-• Returns `true` if they represent the same point, `false` otherwise
-• Implementation: delegates to `ct_eq` (constant-time equality) which cross-multiplies
-  coordinates (X₁·Z₂ vs X₂·Z₁ and Y₁·Z₂ vs Y₂·Z₁) and then converts the `Choice` to `Bool`
+namespace curve25519_dalek.edwards.EdwardsPoint.Insts.CoreCmpPartialEqEdwardsPoint
 
-natural language specs:
-
-• The function always succeeds (no panic) for valid input Edwards points
-• The result is `true` if and only if the two points represent the same point on the curve
--/
-
-/-- **Spec and proof concerning `edwards.PartialEqEdwardsPoint.eq`**:
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::eq`**
 • The function always succeeds (no panic) for valid inputs
 • The result is `true` if and only if the two points represent the same point on the curve
 -/
 @[step]
 theorem eq_spec (self other : EdwardsPoint)
     (h_self_valid : self.IsValid) (h_other_valid : other.IsValid) :
-    eq self other ⦃ result =>
+    eq self other ⦃ (result : Bool) =>
       result = true ↔ self.toPoint = other.toPoint ⦄ := by
   unfold eq
   step*
@@ -76,9 +67,9 @@ theorem eq_spec (self other : EdwardsPoint)
     have : c = Choice.one ↔ c.val = 1#u8 := by
       constructor
       · intro h
-        rw[h, Choice.one]
+        rw [h, Choice.one]
       · apply Choice.eq_one
-    rw[← this]
+    rw [← this]
     exact c_post2 h_self_valid h_other_valid
 
 end curve25519_dalek.edwards.EdwardsPoint.Insts.CoreCmpPartialEqEdwardsPoint

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Identity.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Identity.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Liao Zhang, Oliver Butterley, Hoang Le Truong
 -/
@@ -9,43 +9,34 @@ import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ZERO
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ONE
 
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::identity`
 
-/-! # identity
+Returns the identity element of the Edwards curve in extended twisted Edwards coordinates
+(X, Y, Z, T).
 
-Specification and proof for `EdwardsPoint::identity`.
-
-This function returns the identity element.
-
-**Source**: curve25519-dalek/src/edwards.rs:L409-L416
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
-open Aeneas Aeneas.Std Result Aeneas.Std.WP curve25519_dalek
-open backend.serial.u64.field.FieldElement51
+open Aeneas Aeneas.Std Result Aeneas.Std.WP
+open curve25519_dalek backend.serial.u64.field.FieldElement51
 namespace curve25519_dalek.edwards.EdwardsPoint.Insts.Curve25519_dalekTraitsIdentity
 
-/-
-natural language description:
-
-• Returns the identity element of the Edwards curve in extended
-  twisted Edwards coordinates (X, Y, Z, T)
-
-natural language specs:
-
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::identity`**
 • The function always succeeds (no panic)
-• The resulting EdwardsPoint is the identity element with coordinates (X=0, Y=1, Z=1, T=0)
--/
-
-/-- **Spec and proof** concerning:
- `edwards.EdwardsPoint.Insts.Curve25519_dalekTraitsIdentity.identity`
-- No panic (always returns successfully)
-- The resulting EdwardsPoint is the identity element of the Ed25519 group
+• The resulting EdwardsPoint has coordinates (X = 0, Y = 1, Z = 1, T = 0)
+• The resulting EdwardsPoint is valid
+• The resulting EdwardsPoint represents the identity element of the Ed25519 group
 -/
 @[step]
 theorem identity_spec :
-    identity ⦃ (q : EdwardsPoint) =>
-      Field51_as_Nat q.X = 0 ∧ Field51_as_Nat q.Y = 1 ∧
-      Field51_as_Nat q.Z = 1 ∧ Field51_as_Nat q.T = 0 ∧
-      q.IsValid ∧ q.toPoint = 0 ⦄ := by
+    identity ⦃ (result : EdwardsPoint) =>
+      Field51_as_Nat result.X = 0 ∧
+      Field51_as_Nat result.Y = 1 ∧
+      Field51_as_Nat result.Z = 1 ∧
+      Field51_as_Nat result.T = 0 ∧
+      result.IsValid ∧
+      result.toPoint = 0 ⦄ := by
   unfold identity ZERO ONE
   step*
   have h0 : Field51_as_Nat fe = 0 := by rw [fe_post2]; decide

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/IsSmallOrder.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/IsSmallOrder.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus Dablander
+Authors: Markus Dablander, Liao Zhang, Lacramioara Astefanoaei
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Edwards.Representation
@@ -9,51 +9,33 @@ import Curve25519Dalek.Specs.Edwards.EdwardsPoint.MulByCofactor
 import Curve25519Dalek.Specs.Edwards.EdwardsPoint.Identity
 import Curve25519Dalek.Specs.Edwards.EdwardsPoint.CtEq
 
-/-! # Spec Theorem for `EdwardsPoint::is_small_order`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::is_small_order`
 
-Specification and proof for `EdwardsPoint::is_small_order`.
+Determines whether an `EdwardsPoint` has small order, i.e. lies in the torsion subgroup `E[8]`.
+A point has small order iff multiplying it by the cofactor (= 8) yields the identity element.
 
-This function determines if an Edwards point is of small order (i.e., if it is in E[8]).
-
-**Source**: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
-open Aeneas Aeneas.Std Result Aeneas.Std.WP Edwards
-open curve25519_dalek.backend.serial.u64.field.FieldElement51
+open Aeneas Aeneas.Std Result Aeneas.Std.WP
+open Edwards curve25519_dalek.backend.serial.u64.field.FieldElement51
 namespace curve25519_dalek.edwards.EdwardsPoint
 
-/-
-natural language description:
-
-• Determines whether an EdwardsPoint is in the torsion subgroup E[8]
-
-• A point has small order if multiplying it by the cofactor (= 8) results in the identity element
-
-natural language specs:
-
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::is_small_order`**
 • The function always succeeds (no panic)
-• Returns `true` if and only if the point is in the torsion subgroup E[8]
-• Equivalently, returns `true` iff multiplying by the cofactor yields the identity element
--/
-
-/-- **Spec for `edwards.EdwardsPoint.is_small_order`**:
-- Returns `true` if and only if the point has small order (is in the torsion subgroup E[8])
-- This is determined by checking if multiplying by the cofactor yields the identity element
+• Returns `true` iff multiplying `self` by the cofactor yields the identity, i.e. `self ∈ E[8]`
 -/
 @[step]
 theorem is_small_order_spec (self : EdwardsPoint) (hself : self.IsValid) :
-    is_small_order self ⦃ result =>
-    (result ↔ h • self.toPoint = 0) ⦄ := by
+    is_small_order self ⦃ (result : Bool) =>
+      (result ↔ h • self.toPoint = 0) ⦄ := by
   unfold is_small_order curve25519_dalek.traits.IsIdentity.Blanket.is_identity
   step with mul_by_cofactor_spec as ⟨ep, hep_valid, hep_point⟩
   step with Insts.Curve25519_dalekTraitsIdentity.identity_spec as
     ⟨t, ht_X, ht_Y, ht_Z, ht_T, ht_valid⟩
   step with Insts.SubtleConstantTimeEq.ct_eq_spec as ⟨c, hc1, hc2⟩
-  -- Grind bridges the Array/List coercion gap (ep.X[i]! vs (↑ep.X)[i]!) and < → ≤.
-  -- Grind-free alternative per goal:
-  --   intro i hi; have := hep_valid.X_bounds i hi
-  --   simp_all only [Array.getElem!_Nat_eq, List.Vector.length_val,
-  --     UScalar.ofNatCore_val_eq, getElem!_pos, Nat.reducePow]; omega
+  -- `grind` bridges the Array/List coercion gap (ep.X[i]! vs (↑ep.X)[i]!) and < → ≤.
   · have := hep_valid.X_bounds; grind
   · have := hep_valid.Y_bounds; grind
   · have := hep_valid.Z_bounds; grind

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/IsTorsionFree.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/IsTorsionFree.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
@@ -10,37 +10,23 @@ import Curve25519Dalek.Specs.Edwards.EdwardsPoint.Identity
 import Curve25519Dalek.Specs.Edwards.EdwardsPoint.CtEq
 import Curve25519Dalek.Specs.Edwards.CompressedEdwardsY.Identity
 import Curve25519Dalek.Specs.Constants.BASEPOINT_ORDER_PRIVATE
-/-! # Spec Theorem for `EdwardsPoint::is_torsion_free`
 
-Specification and proof for `EdwardsPoint::is_torsion_free`.
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::is_torsion_free`
 
-This function determines whether an Edwards point is "torsion-free", i.e., is contained
-in the prime-order subgroup. It does so by multiplying the point by the basepoint order L
-and checking whether the result is the identity element.
+Determines whether an EdwardsPoint is in the prime-order subgroup (torsion-free).
 
-**Source**: curve25519-dalek/src/edwards.rs
+• A point is torsion-free if multiplying it by the basepoint order L results in the identity
+  element.
+• Equivalently, the point has no torsion component, i.e., it lies entirely in the prime-order
+  subgroup of the Edwards curve.
+
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
-open Aeneas Aeneas.Std Result Aeneas.Std.WP Edwards
-open curve25519_dalek.backend.serial.u64.field.FieldElement51
+open Aeneas Aeneas.Std Result Aeneas.Std.WP
+open Edwards curve25519_dalek.backend.serial.u64.field.FieldElement51
 namespace curve25519_dalek.edwards.EdwardsPoint
-
-/-
-natural language description:
-
-• Determines whether an EdwardsPoint is in the prime-order subgroup (torsion-free)
-
-• A point is torsion-free if multiplying it by the basepoint order L results in the identity element
-
-• Equivalently, the point has no torsion component, i.e., it lies entirely in the
-  prime-order subgroup of the Edwards curve
-
-natural language specs:
-
-• The function always succeeds (no panic)
-• Returns `true` if and only if the point is in the prime-order subgroup
-• Equivalently, returns `true` iff multiplying by the basepoint order L yields the identity element
--/
 
 private lemma field51_limb_le_of_sum_eq_zero {f : backend.serial.u64.field.FieldElement51}
     (h : Field51_as_Nat f = 0) : ∀ i < 5, (↑f)[i]!.val ≤ 2 ^ 53 := by
@@ -54,17 +40,19 @@ private lemma field51_limb_le_of_sum_eq_one {f : backend.serial.u64.field.FieldE
     Finset.sum_range_succ, Finset.range_one, Finset.sum_singleton] at h
   intro i hi; interval_cases i <;> simp_all <;> omega
 
-/-- **Spec for `edwards.EdwardsPoint.is_torsion_free`**:
-- Returns `true` if and only if the point is torsion-free (is in the prime-order subgroup)
-- This is determined by checking if multiplying by the basepoint order L yields the identity element
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::is_torsion_free`**
+• The function always succeeds (no panic)
+• Returns `true` if and only if the point is torsion-free, i.e. multiplying by the basepoint
+  order L yields the identity element of the Edwards curve
 -/
 @[step]
-theorem is_torsion_free_spec (self : EdwardsPoint) (hself : self.IsValid) :
-    is_torsion_free self ⦃ result =>
-    (result ↔ L • self.toPoint = 0) ⦄ := by
-  unfold is_torsion_free curve25519_dalek.traits.IsIdentity.Blanket.is_identity
+theorem is_torsion_free_spec
+    (self : EdwardsPoint) (hself : self.IsValid) :
+    is_torsion_free self ⦃ (result : Bool) =>
+      (result ↔ L • self.toPoint = 0) ⦄ := by
+  unfold is_torsion_free traits.IsIdentity.Blanket.is_identity
   step as ⟨ep, hep_valid, hep_point⟩
-  · rw [curve25519_dalek.constants.BASEPOINT_ORDER_PRIVATE_spec]
+  · rw [constants.BASEPOINT_ORDER_PRIVATE_spec]
     decide
   step as ⟨t, ht_X, ht_Y, ht_Z, ht_T, ht_valid⟩
   step as ⟨c, hc1, hc2⟩
@@ -76,7 +64,7 @@ theorem is_torsion_free_spec (self : EdwardsPoint) (hself : self.IsValid) :
   · have := field51_limb_le_of_sum_eq_one ht_Z; grind
   · simp only [Bool.Insts.CoreConvertFromChoice.from, spec_ok]
     have ht_zero : t.toPoint = 0 := by
-      have ⟨htpx, htpy⟩ := EdwardsPoint.toPoint_of_isValid ht_valid
+      have ⟨htpx, htpy⟩ := toPoint_of_isValid ht_valid
       ext
       · simp [htpx, toField, ht_X]
       · simp [htpy, toField, ht_Y, ht_Z]
@@ -84,7 +72,7 @@ theorem is_torsion_free_spec (self : EdwardsPoint) (hself : self.IsValid) :
       hc2 hep_valid ht_valid
     rw [ht_zero] at hc_iff
     rw [hep_point] at hc_iff
-    rw [curve25519_dalek.constants.BASEPOINT_ORDER_PRIVATE_spec] at hc_iff
+    rw [constants.BASEPOINT_ORDER_PRIVATE_spec] at hc_iff
     simp only [decide_eq_true_eq]
     have val_iff : c.val = 1#u8 ↔ c = Choice.one := by
       cases c with | mk val valid => simp [Choice.one]

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Mul.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Mul.lean
@@ -1,86 +1,73 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus Dablander
+Authors: Markus Dablander, Hoang Le Truong, Alessandro D'Angelo
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Backend.Serial.ScalarMul.VariableBase.Mul
-import Curve25519Dalek.ExternallyVerified
 
-/-! # Spec Theorems for `EdwardsPoint::mul`
+/-!
+# Spec theorems for `EdwardsPoint::mul` and `Scalar::mul`
 
-Specifications and proofs for scalar multiplication of Edwards points.
+Scalar multiplication on Edwards points: given a valid Edwards point `P` and a
+canonical scalar `s` (i.e., `s` represents a natural number less than `2^255`), the
+result is `[s] P`, the elliptic curve group element obtained by adding `P` to itself
+`s` times.
 
-Three trait implementations are covered here:
+The Rust source defines four trait implementations of `core::ops::Mul` producing an
+`EdwardsPoint`:
 
-- `Shared0EdwardsPoint.Insts.CoreOpsArithMulSharedAScalarEdwardsPoint.mul` —
-  the core implementation:
-  `&EdwardsPoint * &Scalar → EdwardsPoint`, delegating to
-  `backend::variable_base_mul`.
+- `Mul<&Scalar> for &EdwardsPoint`: the core implementation, performing variable-base
+  scalar multiplication via the selected backend.
+- `Mul<&EdwardsPoint> for &Scalar`: the commutative variant, delegating to the core
+  implementation with the operands swapped.
+- `Mul<Scalar> for &EdwardsPoint`: a non-borrow variant on the right-hand operand,
+  delegating to the core implementation.
+- `Mul<EdwardsPoint> for Scalar`: the fully non-borrow variant, delegating to the
+  commutative variant.
 
-- `Shared0Scalar.Insts.CoreOpsArithMulSharedAEdwardsPointEdwardsPoint.mul` —
-  the commutative variant: `&Scalar * &EdwardsPoint → EdwardsPoint`,
-  delegating to the above with swapped arguments.
-
-**Source**: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.Shared0EdwardsPoint.Insts.CoreOpsArithMulSharedAScalarEdwardsPoint
 
-/-
-natural language description:
-
-• Takes a valid Edwards point (self : edwards.EdwardsPoint) and a canonical
-  scalar (scalar : scalar.Scalar)
-• Returns the scalar multiple [scalar]self, i.e., the point added to itself
-  scalar times
-• Delegates to backend.variable_base_mul
-
-natural language specs:
-
-• The function always succeeds (no panic) for valid input EdwardsPoints e
-  and canonical Scalars s
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul`**
+(trait impl `Mul<&Scalar> for &EdwardsPoint`).
+• The function always succeeds (no panic) for a valid input EdwardsPoint `self` and a
+  canonical Scalar `scalar`
 • The result is a valid EdwardsPoint
-• The result is mathematically correct, i.e.,
-  result.toPoint = e.toPoint + .. + e.toPoint (s-times)
--/
-
-/-- **Spec and proof concerning
-`Shared0EdwardsPoint.Insts.CoreOpsArithMulSharedAScalarEdwardsPoint.mul`**:
-• The function always succeeds (no panic) for valid input EdwardsPoints e
-  and canonical Scalars s
-• The result is a valid EdwardsPoint
-• The result is mathematically correct, i.e.,
-  result.toPoint = e.toPoint + .. + e.toPoint (s-times)
+• `result.toPoint` equals `(U8x32_as_Nat scalar.bytes) • self.toPoint`, i.e., scalar
+  multiplication of `self.toPoint` by the natural number encoded by `scalar.bytes`
 -/
 @[step]
-theorem mul_spec (e : edwards.EdwardsPoint) (s : scalar.Scalar)
-    (h_s_canonical : U8x32_as_Nat s.bytes < 2 ^ 255)
-    (h_e_valid : e.IsValid) :
-    mul e s ⦃ result =>
-    result.IsValid ∧
-    result.toPoint = (U8x32_as_Nat s.bytes) • e.toPoint ⦄ := by
+theorem mul_spec
+    (self : edwards.EdwardsPoint) (scalar : scalar.Scalar)
+    (h_scalar_canonical : U8x32_as_Nat scalar.bytes < 2 ^ 255)
+    (h_self_valid : self.IsValid) :
+    mul self scalar ⦃ (result : edwards.EdwardsPoint) =>
+      result.IsValid ∧
+      result.toPoint = (U8x32_as_Nat scalar.bytes) • self.toPoint ⦄ := by
   -- `U8x32_as_Nat < 2^255` forces the top byte to have a clear high bit
-  -- (i.e., `s.bytes[31].val ≤ 127`), which is the precondition of
+  -- (i.e., `scalar.bytes[31].val ≤ 127`), which is the precondition of
   -- `variable_base.mul_spec`.
-  have h_top : (s.bytes[31]!).val ≤ 127 := by
+  have h_top : (scalar.bytes[31]!).val ≤ 127 := by
     -- If `bytes[31] ≥ 128` then the top byte alone contributes `≥ 2^248 * 128 = 2^255`,
     -- contradicting `U8x32_as_Nat < 2^255`.
     by_contra h_neg
     push_neg at h_neg
-    unfold U8x32_as_Nat at h_s_canonical
-    rw [Finset.sum_range_succ] at h_s_canonical
-    have h_high_ge : 2 ^ 255 ≤ 2 ^ (8 * 31) * (s.bytes[31]!).val := by
+    unfold U8x32_as_Nat at h_scalar_canonical
+    rw [Finset.sum_range_succ] at h_scalar_canonical
+    have h_high_ge : 2 ^ 255 ≤ 2 ^ (8 * 31) * (scalar.bytes[31]!).val := by
       calc 2 ^ 255 = 2 ^ (8 * 31) * 128 := by norm_num
-        _ ≤ 2 ^ (8 * 31) * (s.bytes[31]!).val := Nat.mul_le_mul_left _ h_neg
+        _ ≤ 2 ^ (8 * 31) * (scalar.bytes[31]!).val := Nat.mul_le_mul_left _ h_neg
     omega
   unfold mul backend.variable_base_mul backend.get_selected_backend
   simp only [step_simps]
   let* ⟨ result, result_valid, result_point ⟩ ←
-    curve25519_dalek.backend.serial.scalar_mul.variable_base.mul_spec e h_e_valid s h_top
+    backend.serial.scalar_mul.variable_base.mul_spec self h_self_valid scalar h_top
   refine ⟨result_valid, ?_⟩
   rw [result_point, natCast_zsmul]
 
@@ -88,130 +75,69 @@ end curve25519_dalek.Shared0EdwardsPoint.Insts.CoreOpsArithMulSharedAScalarEdwar
 
 namespace curve25519_dalek.Shared0Scalar.Insts.CoreOpsArithMulSharedAEdwardsPointEdwardsPoint
 
-/-
-natural language description:
-
-• Takes a canonical scalar (self : scalar.Scalar) and a valid Edwards point
-  (point : edwards.EdwardsPoint)
-• Returns the scalar multiple [self]point, i.e., the point added to itself
-  self times
-• This is the commutative variant (Scalar * Point rather than Point * Scalar);
-  it simply delegates to
-  Shared0EdwardsPoint.Insts.CoreOpsArithMulSharedAScalarEdwardsPoint.mul
-  with arguments swapped, so no independent computation takes place
-
-natural language specs:
-
-• The function always succeeds (no panic) for canonical input Scalars s and
-  valid input EdwardsPoints e
+/-- **Spec theorem for `curve25519_dalek::scalar::Scalar::mul`**
+(trait impl `Mul<&EdwardsPoint> for &Scalar`).
+• The function always succeeds (no panic) for a canonical input Scalar `self` and a
+  valid input EdwardsPoint `point`
 • The result is a valid EdwardsPoint
-• The result is mathematically correct, i.e.,
-  result.toPoint = e.toPoint + .. + e.toPoint (s-times)
--/
-
-/-- **Spec and proof concerning
-`Shared0Scalar.Insts.CoreOpsArithMulSharedAEdwardsPointEdwardsPoint.mul`**:
-• The function always succeeds (no panic) for canonical input Scalars s and
-  valid input EdwardsPoints e
-• The result is a valid EdwardsPoint
-• The result is mathematically correct, i.e.,
-  result.toPoint = e.toPoint + .. + e.toPoint (s-times)
+• `result.toPoint` equals `(U8x32_as_Nat self.bytes) • point.toPoint`, i.e., scalar
+  multiplication of `point.toPoint` by the natural number encoded by `self.bytes`
 -/
 @[step]
-theorem mul_spec (s : scalar.Scalar) (e : edwards.EdwardsPoint)
-    (h_s_canonical : U8x32_as_Nat s.bytes < 2 ^ 255)
-    (h_e_valid : e.IsValid) :
-    mul s e ⦃ result =>
-    result.IsValid ∧
-    result.toPoint = (U8x32_as_Nat s.bytes) • e.toPoint ⦄ := by
+theorem mul_spec
+    (self : scalar.Scalar) (point : edwards.EdwardsPoint)
+    (h_self_canonical : U8x32_as_Nat self.bytes < 2 ^ 255)
+    (h_point_valid : point.IsValid) :
+    mul self point ⦃ (result : edwards.EdwardsPoint) =>
+      result.IsValid ∧
+      result.toPoint = (U8x32_as_Nat self.bytes) • point.toPoint ⦄ := by
   exact Shared0EdwardsPoint.Insts.CoreOpsArithMulSharedAScalarEdwardsPoint.mul_spec
-    e s h_s_canonical h_e_valid
+    point self h_self_canonical h_point_valid
 
 end curve25519_dalek.Shared0Scalar.Insts.CoreOpsArithMulSharedAEdwardsPointEdwardsPoint
 
 namespace curve25519_dalek.SharedAEdwardsPoint.Insts.CoreOpsArithMulScalarEdwardsPoint
 
-/-
-natural language description:
-
-• Takes a valid Edwards point (self : edwards.EdwardsPoint) and a canonical
-  scalar (rhs : scalar.Scalar)
-• Returns the scalar multiple [rhs]self, i.e., the point added to itself rhs
-  times
-• This is the non-borrow variant (`&'a EdwardsPoint * Scalar` rather than
-  `&EdwardsPoint * &Scalar`); it simply delegates to
-  Shared0EdwardsPoint.Insts.CoreOpsArithMulSharedAScalarEdwardsPoint.mul
-  with the same arguments, so no independent computation takes place
-
-natural language specs:
-
-• The function always succeeds (no panic) for valid input EdwardsPoints e
-  and canonical Scalars s
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul`**
+(trait impl `Mul<Scalar> for &EdwardsPoint`).
+• The function always succeeds (no panic) for a valid input EdwardsPoint `self` and a
+  canonical Scalar `rhs`
 • The result is a valid EdwardsPoint
-• The result is mathematically correct, i.e.,
-  result.toPoint = e.toPoint + .. + e.toPoint (s-times)
--/
-
-/-- **Spec and proof concerning
-`SharedAEdwardsPoint.Insts.CoreOpsArithMulScalarEdwardsPoint.mul`**:
-• The function always succeeds (no panic) for valid input EdwardsPoints e
-  and canonical Scalars s
-• The result is a valid EdwardsPoint
-• The result is mathematically correct, i.e.,
-  result.toPoint = e.toPoint + .. + e.toPoint (s-times)
+• `result.toPoint` equals `(U8x32_as_Nat rhs.bytes) • self.toPoint`, i.e., scalar
+  multiplication of `self.toPoint` by the natural number encoded by `rhs.bytes`
 -/
 @[step]
-theorem mul_spec (e : edwards.EdwardsPoint) (s : scalar.Scalar)
-    (h_s_canonical : U8x32_as_Nat s.bytes < 2 ^ 255)
-    (h_e_valid : e.IsValid) :
-      mul e s ⦃ result =>
+theorem mul_spec
+    (self : edwards.EdwardsPoint) (rhs : scalar.Scalar)
+    (h_rhs_canonical : U8x32_as_Nat rhs.bytes < 2 ^ 255)
+    (h_self_valid : self.IsValid) :
+    mul self rhs ⦃ (result : edwards.EdwardsPoint) =>
       result.IsValid ∧
-      result.toPoint = ((U8x32_as_Nat s.bytes)) • e.toPoint ⦄ := by
-  exact curve25519_dalek.Shared0Scalar.Insts.CoreOpsArithMulSharedAEdwardsPointEdwardsPoint.mul_spec
-    s e h_s_canonical h_e_valid
+      result.toPoint = (U8x32_as_Nat rhs.bytes) • self.toPoint ⦄ := by
+  exact Shared0Scalar.Insts.CoreOpsArithMulSharedAEdwardsPointEdwardsPoint.mul_spec
+    rhs self h_rhs_canonical h_self_valid
 
 end curve25519_dalek.SharedAEdwardsPoint.Insts.CoreOpsArithMulScalarEdwardsPoint
 
 namespace curve25519_dalek.scalar.Scalar.Insts.CoreOpsArithMulEdwardsPointEdwardsPoint
 
-/-
-natural language description:
-
-• Takes a canonical scalar (self : scalar.Scalar) and a valid Edwards point
-  (rhs : edwards.EdwardsPoint)
-• Returns the scalar multiple [self]rhs, i.e., the point added to itself
-  self times
-• This is the fully non-borrow variant (`Scalar * EdwardsPoint` rather than
-  `&Scalar * &EdwardsPoint`); it simply delegates to
-  Shared0Scalar.Insts.CoreOpsArithMulSharedAEdwardsPointEdwardsPoint.mul
-  with the same arguments, so no independent computation takes place
-
-natural language specs:
-
-• The function always succeeds (no panic) for canonical input Scalars s and
-  valid input EdwardsPoints e
+/-- **Spec theorem for `curve25519_dalek::scalar::Scalar::mul`**
+(trait impl `Mul<EdwardsPoint> for Scalar`).
+• The function always succeeds (no panic) for a canonical input Scalar `self` and a
+  valid input EdwardsPoint `rhs`
 • The result is a valid EdwardsPoint
-• The result is mathematically correct, i.e.,
-  result.toPoint = e.toPoint + .. + e.toPoint (s-times)
--/
-
-/-- **Spec and proof concerning
-`scalar.Scalar.Insts.CoreOpsArithMulEdwardsPointEdwardsPoint.mul`**:
-• The function always succeeds (no panic) for canonical input Scalars s and
-  valid input EdwardsPoints e
-• The result is a valid EdwardsPoint
-• The result is mathematically correct, i.e.,
-  result.toPoint = e.toPoint + .. + e.toPoint (s-times)
+• `result.toPoint` equals `(U8x32_as_Nat self.bytes) • rhs.toPoint`, i.e., scalar
+  multiplication of `rhs.toPoint` by the natural number encoded by `self.bytes`
 -/
 @[step]
-theorem mul_spec (s : scalar.Scalar) (e : edwards.EdwardsPoint)
-    (h_s_canonical : U8x32_as_Nat s.bytes < 2 ^ 255)
-    (h_e_valid : e.IsValid) :
-    mul s e ⦃ result =>
+theorem mul_spec
+    (self : scalar.Scalar) (rhs : edwards.EdwardsPoint)
+    (h_self_canonical : U8x32_as_Nat self.bytes < 2 ^ 255)
+    (h_rhs_valid : rhs.IsValid) :
+    mul self rhs ⦃ (result : edwards.EdwardsPoint) =>
       result.IsValid ∧
-      result.toPoint = ((U8x32_as_Nat s.bytes)) • e.toPoint ⦄ := by
+      result.toPoint = (U8x32_as_Nat self.bytes) • rhs.toPoint ⦄ := by
   exact SharedAEdwardsPoint.Insts.CoreOpsArithMulScalarEdwardsPoint.mul_spec
-    e s h_s_canonical h_e_valid
-
+    rhs self h_self_canonical h_rhs_valid
 
 end curve25519_dalek.scalar.Scalar.Insts.CoreOpsArithMulEdwardsPointEdwardsPoint

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulBase.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulBase.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
@@ -11,52 +11,34 @@ import Curve25519Dalek.Specs.Edwards.EdwardsPoint.Mul
 import Curve25519Dalek.Specs.Backend.Serial.U64.Constants.Ed25519BasepointPoint
 import Curve25519Dalek.ExternallyVerified
 
-/-! # Spec Theorem for `EdwardsPoint::mul_base`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_base`
 
-Specification and proof for
-`curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::mul_base`.
+Computes the scalar multiplication `[s]B` where `B` is the Edwards basepoint. The
+implementation delegates to scalar-point multiplication on the constant basepoint
+`backend.serial.u64.constants.ED25519_BASEPOINT_POINT`.
 
-This function performs scalar multiplication of the Edwards basepoint by delegating to
-scalar-point multiplication on the fixed basepoint.
-
-**Source**: curve25519-dalek/src/edwards.rs, lines 876:4-886:5
-
-## TODO
-- Complete proof
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-open curve25519_dalek.montgomery
 open curve25519_dalek.backend.serial.u64
 namespace curve25519_dalek.edwards.EdwardsPoint
 
-/-
-natural language description:
-
-• Computes the scalar multiplication [s]B where B is the Edwards basepoint.
-
-• The implementation delegates to `edwards.MulSharedAScalarEdwardsPointEdwardsPoint.mul`
-  with the constant basepoint `backend.serial.u64.constants.ED25519_BASEPOINT_POINT`.
-
-natural language specs:
-
-• The function always succeeds (no panic)
-• The returned EdwardsPoint is exactly the result of scalar multiplication with the basepoint
--/
-
-/-- **Spec and proof concerning `edwards.EdwardsPoint.mul_base`**:
-- No panic (always returns successfully)
-- Delegates to scalar multiplication with the Edwards basepoint constant
-- The returned EdwardsPoint equals the output of that scalar multiplication
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_base`**
+• Given a canonically-encoded scalar (`U8x32_as_Nat scalar.bytes < 2 ^ 255`),
+  the function always succeeds (no panic).
+• The returned `EdwardsPoint` is a valid Edwards point.
+• The returned `EdwardsPoint` represents `[s]B`, the scalar multiplication of
+  the input `scalar` with the Edwards basepoint.
 -/
 @[step]
 theorem mul_base_spec (scalar : scalar.Scalar)
     (h_s_canonical : U8x32_as_Nat scalar.bytes < 2 ^ 255) :
-    mul_base scalar ⦃ res =>
-    EdwardsPoint.IsValid res ∧
-    res.toPoint = (U8x32_as_Nat scalar.bytes) • _root_.Edwards.basepoint ⦄ := by
-  unfold mul_base
-      curve25519_dalek.SharedAScalar.Insts.CoreOpsArithMulEdwardsPointEdwardsPoint.mul
+    mul_base scalar ⦃ (res : EdwardsPoint) =>
+      EdwardsPoint.IsValid res ∧
+      res.toPoint = (U8x32_as_Nat scalar.bytes) • _root_.Edwards.basepoint ⦄ := by
+  unfold mul_base SharedAScalar.Insts.CoreOpsArithMulEdwardsPointEdwardsPoint.mul
   let* ⟨ ep, ep_post1, ep_post2, ep_post3, ep_post4, ep_post5, ep_post6 ⟩
     ← constants.ED25519_BASEPOINT_POINT_spec
   let* ⟨ res, res_post1, res_post2 ⟩

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulBaseClamped.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulBaseClamped.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
@@ -10,53 +10,38 @@ import Curve25519Dalek.Math.Edwards.Basepoint
 import Curve25519Dalek.Specs.Edwards.EdwardsPoint.MulBase
 import Curve25519Dalek.Specs.Scalar.ClampInteger
 
-/-! # Spec Theorem for `EdwardsPoint::mul_base_clamped`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_base_clamped`
 
-Specification and proof for
-`curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::mul_base_clamped`.
+Performs scalar multiplication by the Edwards basepoint after clamping the
+32-byte input to a valid scalar via `scalar.clamp_integer`. The computation
+of the basepoint multiplication with the clamped scalar is delegated to
+`EdwardsPoint.mul_base`.
 
-This function performs scalar multiplication by the Edwards basepoint after
-clamping the input bytes to a valid scalar, delegating to `EdwardsPoint.mul_base`.
-
-**Source**: curve25519-dalek/src/edwards.rs, lines 906:4-914:5
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-open curve25519_dalek.edwards
-open curve25519_dalek.backend.serial.u64
-
+open curve25519_dalek.edwards curve25519_dalek.backend.serial.u64
 namespace curve25519_dalek.edwards.EdwardsPoint
 
-/-
-natural language description:
-
-• Clamps the 32-byte input to a valid scalar using `scalar.clamp_integer`.
-
-• Computes the Edwards basepoint multiplication with the clamped scalar by
-  delegating to `EdwardsPoint.mul_base`.
-
-natural language specs:
-
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_base_clamped`**
 • The function always succeeds (no panic)
-• The result is the Edwards basepoint multiplication of the clamped scalar
--/
-
-/-- **Spec and proof concerning `edwards.EdwardsPoint.mul_base_clamped`**:
-- No panic (always returns successfully)
-- Clamps input bytes with `scalar.clamp_integer`
-- Delegates to `edwards.EdwardsPoint.mul_base` with the clamped scalar
-- The returned EdwardsPoint matches the basepoint multiplication result
+• The returned `EdwardsPoint` is a valid Edwards point
+• The returned point equals the scalar multiplication of the Edwards basepoint
+  by a clamped scalar derived from the input bytes, divisible by the cofactor
+  `h` and lying in `[2^254, 2^255)`
 -/
 @[step]
 theorem mul_base_clamped_spec (bytes : Array U8 32#usize) :
     mul_base_clamped bytes ⦃ (result : EdwardsPoint) =>
       EdwardsPoint.IsValid result ∧
       (∃ clamped_scalar,
-      h ∣ U8x32_as_Nat clamped_scalar ∧
-      U8x32_as_Nat clamped_scalar < 2 ^ 255 ∧
-      2 ^ 254 ≤ U8x32_as_Nat clamped_scalar ∧
-      result.toPoint = ((U8x32_as_Nat clamped_scalar) • _root_.Edwards.basepoint)) ⦄ := by
-    unfold mul_base_clamped
-    step*
+        h ∣ U8x32_as_Nat clamped_scalar ∧
+        U8x32_as_Nat clamped_scalar < 2 ^ 255 ∧
+        2 ^ 254 ≤ U8x32_as_Nat clamped_scalar ∧
+        result.toPoint = ((U8x32_as_Nat clamped_scalar) • _root_.Edwards.basepoint)) ⦄ := by
+  unfold mul_base_clamped
+  step*
 
 end curve25519_dalek.edwards.EdwardsPoint

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulByCofactor.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulByCofactor.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Dablander, Liao Zhang
 -/
@@ -7,38 +7,26 @@ import Curve25519Dalek.Funs
 import Curve25519Dalek.Specs.Edwards.EdwardsPoint.MulByPow2
 import Curve25519Dalek.Math.Edwards.Representation
 
-/-! # Spec Theorem for `EdwardsPoint::mul_by_cofactor`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_by_cofactor`
 
-Specification and proof for `EdwardsPoint::mul_by_cofactor`.
+Takes an `EdwardsPoint` `e` and returns the result of multiplying the point by the cofactor
+`8 = 2 ^ 3` (i.e., computes `[8]e` where `e` is the input point).
 
-This function computes 8*e (the Edwards point e multiplied by the cofactor 8)
-by calling mul_by_pow_2 with k=3 (since 2^3 = 8).
-
-**Source**: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.edwards.EdwardsPoint
 
-/-
-natural language description:
-
-• Takes an EdwardsPoint e and returns the result of multiplying the point by the cofactor 8 = 2 ^ 3
-(i.e., computes [8]e where e is the input point)
-
-natural language specs:
-
-• The function always succeeds (no panic)
-• Returns an EdwardsPoint that represents 8e = (2 ^ 3) * e
--/
-
-/-- **Spec and proof concerning `edwards.EdwardsPoint.mul_by_cofactor`**:
-- No panic (always returns successfully)
-- Returns an EdwardsPoint that represents 8e = (2 ^ 3) * e
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_by_cofactor`**
+• The function always succeeds (no panic) for valid input `EdwardsPoint`s
+• Returns a valid `EdwardsPoint`
+• `result.toPoint` equals `8 • self.toPoint` (i.e. `[8]e`, multiplication by the cofactor)
 -/
 @[step]
 theorem mul_by_cofactor_spec (self : EdwardsPoint) (hself : self.IsValid) :
-    mul_by_cofactor self ⦃ result =>
+    mul_by_cofactor self ⦃ (result : EdwardsPoint) =>
       result.IsValid ∧
       result.toPoint = h • self.toPoint ⦄ := by
   unfold mul_by_cofactor

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulByPow2.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulByPow2.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Dablander, Alessandro D'Angelo
 -/
@@ -10,36 +10,22 @@ import Curve25519Dalek.Specs.Edwards.EdwardsPoint.AsProjective
 import Curve25519Dalek.Specs.Backend.Serial.CurveModels.ProjectivePoint.Double
 import Curve25519Dalek.Specs.Backend.Serial.CurveModels.CompletedPoint.AsProjective
 import Curve25519Dalek.Specs.Backend.Serial.CurveModels.CompletedPoint.AsExtended
-import Mathlib
 
-/-! # Spec Theorem for `EdwardsPoint::mul_by_pow_2`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_by_pow_2`
 
-Specification and proof for `EdwardsPoint::mul_by_pow_2`.
+Takes an `EdwardsPoint` `self` and a positive integer `k`, and returns the result of doubling
+the point `k` times (i.e., computes `[2^k] self` where `self` is the input point) via successive
+doublings.
 
-This function computes [2^k]e (the Edwards point e doubled k times for some natural k > 0)
-by successive doublings.
-
-**Source**: curve25519-dalek/src/edwards.rs:1328-1340
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open Edwards curve25519_dalek.backend.serial.curve_models
-open curve25519_dalek.backend.serial.curve_models.ProjectivePoint
-open curve25519_dalek.backend.serial.u64.field
-
+  curve25519_dalek.backend.serial.curve_models.ProjectivePoint
+  curve25519_dalek.backend.serial.u64.field
 namespace curve25519_dalek.edwards.EdwardsPoint
-
-/-
-natural language description:
-
-• Takes an EdwardsPoint e and a positive integer k, and returns the result of doubling the point
-k times (i.e., computes [2^k]e where e is the input point)
-
-natural language specs:
-
-• For k = 1, returns double(e)
-• For k > 1, satisfies the recursive property: mul_by_pow_2(e, k) = double(mul_by_pow_2(e, k-1))
--/
 
 /-- Loop spec for `mul_by_pow_2_loop`: repeatedly doubles `s` via
 `ProjectivePoint.double` + `CompletedPoint.as_projective` from counter `i` up to `k - 1`.
@@ -119,14 +105,15 @@ theorem mul_by_pow_2_loop_spec
     obtain ⟨h_on, hX, hY, hZ, hpt⟩ := result_post
     exact ⟨hX, hY, hZ, h_on, hpt⟩
 
-/-- **Spec and proof concerning `edwards.EdwardsPoint.mul_by_pow_2`**:
-- For k = 1, returns the doubled point 2e for the input point e
-- For k > 1, returns a point equal to double(mul_by_pow_2(e, k-1))
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_by_pow_2`**
+• Does not panic for a valid input point `self` and `k > 0`
+• The result is a valid `EdwardsPoint`
+• The result equals `2 ^ k` scalar-multiplied with the input point `self`
 -/
 @[step]
 theorem mul_by_pow_2_spec (self : EdwardsPoint) (k : U32)
     (hself : self.IsValid) (hk : k.val > 0) :
-    mul_by_pow_2 self k ⦃ result =>
+    mul_by_pow_2 self k ⦃ (result : EdwardsPoint) =>
       result.IsValid ∧
       result.toPoint = (2 ^ k.val) • self.toPoint ⦄ := by
   unfold mul_by_pow_2
@@ -167,6 +154,5 @@ theorem mul_by_pow_2_spec (self : EdwardsPoint) (k : U32)
   fcongr 1
   rw [show k.val = (k.val - 1) + 1 from by omega, pow_succ, mul_comm]
   agrind
-
 
 end curve25519_dalek.edwards.EdwardsPoint

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulClamped.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulClamped.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
@@ -9,66 +9,44 @@ import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Edwards.EdwardsPoint.Mul
 import Curve25519Dalek.Specs.Scalar.ClampInteger
 
-/-! # Spec Theorem for `EdwardsPoint::mul_clamped`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_clamped`
 
-Specification and proof for
-`curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::mul_clamped`.
+Performs scalar multiplication of an Edwards point after clamping the 32-byte input
+to a valid scalar via `curve25519_dalek::scalar::clamp_integer`, then delegating to
+the scalar–point multiplication `<Scalar as Mul<EdwardsPoint>>::mul`. The clamped
+scalar is not necessarily reduced modulo the group order `L`, but clamping forces
+it to be divisible by the cofactor `h = 8` and to lie in `[2^254, 2^255)`, which
+suffices for correctness of variable-base scalar multiplication.
 
-This function performs scalar multiplication of an Edwards point after
-clamping the input bytes to a valid scalar, delegating to `Scalar * EdwardsPoint`
-multiplication.
-
-Note: The clamped scalar is **not** necessarily reduced modulo the group order `L`,
-which means the usual scalar canonicity invariant (`< L`) does not hold. However,
-clamping guarantees `< 2^255`, which suffices for correctness of variable-base
-scalar multiplication (see the Rust source comment at line 892).
-
-**Source**: curve25519-dalek/src/edwards.rs, lines 891:4-903:5
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-open curve25519_dalek.edwards
-open curve25519_dalek.backend.serial.u64
-
-
-
+open curve25519_dalek.edwards curve25519_dalek.backend.serial.u64
 namespace curve25519_dalek.edwards.EdwardsPoint
 
-
-
-/-
-natural language description:
-
-• Clamps the 32-byte input to a valid scalar using `scalar.clamp_integer`.
-
-• Computes the scalar multiplication of `self` with the clamped scalar by
-  delegating to `Scalar * EdwardsPoint` multiplication
-  (`scalar.Scalar.Insts.CoreOpsArithMulEdwardsPointEdwardsPoint.mul`).
-
-natural language specs:
-
-• The function always succeeds (no panic)
-• The result is a valid Edwards point
-• The result is the scalar multiplication of the clamped scalar with `self`
--/
-
-/-- **Spec and proof concerning `edwards.EdwardsPoint.mul_clamped`**:
-- No panic (always returns successfully)
-- Clamps input bytes with `scalar.clamp_integer`
-- Delegates to `Scalar * EdwardsPoint` multiplication with the clamped scalar
-- The returned EdwardsPoint matches the scalar multiplication result
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_clamped`**
+• The function always succeeds (no panic) for a valid input EdwardsPoint `self`
+• The result is a valid EdwardsPoint
+• There exists a clamped 32-byte scalar `c` (the bitwise-clamped form of `bytes`)
+  such that `c` is divisible by the cofactor `h = 8`
+• `c < 2^255`
+• `2^254 ≤ c`
+• `result.toPoint = c • self.toPoint`, i.e., scalar multiplication of `self.toPoint`
+  by the natural number `c`
 -/
 @[step]
 theorem mul_clamped_spec (self : EdwardsPoint) (bytes : Array U8 32#usize)
     (h_self_valid : self.IsValid) :
     mul_clamped self bytes ⦃ (result : EdwardsPoint) =>
-      EdwardsPoint.IsValid result ∧
+      result.IsValid ∧
       (∃ clamped_scalar,
-      h ∣ U8x32_as_Nat clamped_scalar ∧
-      U8x32_as_Nat clamped_scalar < 2 ^ 255 ∧
-      2 ^ 254 ≤ U8x32_as_Nat clamped_scalar ∧
-      result.toPoint = (((U8x32_as_Nat clamped_scalar)) • self.toPoint)) ⦄ := by
-    unfold mul_clamped
-    step*
+        h ∣ U8x32_as_Nat clamped_scalar ∧
+        U8x32_as_Nat clamped_scalar < 2 ^ 255 ∧
+        2 ^ 254 ≤ U8x32_as_Nat clamped_scalar ∧
+        result.toPoint = (U8x32_as_Nat clamped_scalar) • self.toPoint) ⦄ := by
+  unfold mul_clamped
+  step*
 
 end curve25519_dalek.edwards.EdwardsPoint

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Neg.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Neg.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
@@ -7,37 +7,22 @@ import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Neg
 import Curve25519Dalek.Math.Montgomery.Curve
-/-! # Spec Theorem for `EdwardsPoint::neg`
 
-Specification and proof for the `Neg` trait implementation for Edwards points.
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::neg`
 
-This function negates an Edwards point via elliptic curve negation: it negates the
-X and T coordinates while keeping Y and Z unchanged, which corresponds to negating
+Negate an Edwards point via elliptic curve negation: negates the X and T
+coordinates while keeping Y and Z unchanged, which corresponds to negating
 the x-coordinate in affine form.
 
-**Source**: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-open curve25519_dalek.edwards.EdwardsPoint
-open curve25519_dalek.backend.serial.u64.field
+open curve25519_dalek.edwards.EdwardsPoint curve25519_dalek.backend.serial.u64.field
 namespace curve25519_dalek.Shared0EdwardsPoint.Insts.CoreOpsArithNegEdwardsPoint
 
-/-
-natural language description:
-
-• Takes an EdwardsPoint `self`
-• Returns its negation as an EdwardsPoint via elliptic curve group negation
-• Implementation: negates the X and T coordinates while keeping Y and Z unchanged
-
-natural language specs:
-
-• The function always succeeds (no panic) for valid input Edwards points
-• The result is a valid Edwards point
-• The result represents the negation of the input (in the context of elliptic curve negation)
--/
-
-/-- **Spec and proof concerning `Shared0EdwardsPoint.Insts.CoreOpsArithNegEdwardsPoint.neg`**:
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::neg`**
 • The function always succeeds (no panic) for valid inputs
 • The result is a valid Edwards point
 • The result represents the negation of the input (in the context of elliptic curve negation)
@@ -56,25 +41,25 @@ theorem neg_spec
   have := h_self_valid.T_bounds
   step*
   simp only [Montgomery.lift_mod_eq_iff, Nat.cast_add, Nat.cast_zero] at fe_post1
-  rw[← FieldElement51.toField, ← FieldElement51.toField ] at fe_post1
+  rw [← FieldElement51.toField, ← FieldElement51.toField] at fe_post1
   simp only [Montgomery.lift_mod_eq_iff, Nat.cast_add, Nat.cast_zero] at fe1_post1
-  rw[← FieldElement51.toField, ← FieldElement51.toField ] at fe1_post1
-  have fe_neg: fe.toField=-self.X.toField  := by grind
-  have fe1_neg: fe1.toField =-self.T.toField := by grind
-  have : ({ X := fe, Y := self.Y, Z := self.Z, T := fe1 }:edwards.EdwardsPoint).IsValid := by
+  rw [← FieldElement51.toField, ← FieldElement51.toField] at fe1_post1
+  have fe_neg : fe.toField = -self.X.toField := by grind
+  have fe1_neg : fe1.toField = -self.T.toField := by grind
+  have : ({ X := fe, Y := self.Y, Z := self.Z, T := fe1 } : edwards.EdwardsPoint).IsValid := by
     refine
       { Z_ne_zero := ?_, T_relation := ?_, on_curve := ?_,
         X_bounds := ?_, Y_bounds := ?_, Z_bounds := ?_, T_bounds := ?_ }
     · have := h_self_valid.Z_ne_zero
-      simp[this]
+      simp [this]
     · have := h_self_valid.T_relation
       simp only
-      rw[fe_neg, fe1_neg]
+      rw [fe_neg, fe1_neg]
       grind
     · simp only
-      rw[fe_neg]
+      rw [fe_neg]
       have := h_self_valid.on_curve
-      simp at this
+      simp only at this
       grind
     · grind
     · grind
@@ -86,16 +71,5 @@ theorem neg_spec
   · simp only [Edwards.neg_x]
     field_simp
   · simp only [Edwards.neg_y]
-
-
-
-
-
-
-
-
-
-
-
 
 end curve25519_dalek.Shared0EdwardsPoint.Insts.CoreOpsArithNegEdwardsPoint

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Sub.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/Sub.lean
@@ -1,47 +1,34 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus Dablander, Hoang Le Truong
+Authors: Markus Dablander, Hoang Le Truong, Alessandro D'Angelo
 -/
 import Curve25519Dalek.Funs
-import Curve25519Dalek.ExternallyVerified
 import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Edwards.EdwardsPoint.AsProjectiveNiels
 import Curve25519Dalek.Specs.Backend.Serial.CurveModels.ProjectiveNielsPoint.Sub
 import Curve25519Dalek.Specs.Backend.Serial.CurveModels.CompletedPoint.AsExtended
 
-/-! # Spec Theorem for `EdwardsPoint::sub`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::sub`
 
-Specification and proof for the `Sub` trait implementation for Edwards points.
+Subtract two Edwards points via elliptic curve group subtraction, returning their
+difference as an EdwardsPoint.
 
-This function subtracts two Edwards points via elliptic curve subtraction using the
-extended twisted Edwards coordinates: it converts the second operand to projective niels
-form, performs the subtraction in completed point coordinates, and converts back to
-extended coordinates.
+- The core implementation (`&EdwardsPoint - &EdwardsPoint`) takes two EdwardsPoints by
+  reference, converts the right-hand operand to projective niels form, performs the
+  subtraction in completed point coordinates, and converts the result back to extended
+  twisted Edwards coordinates.
+- The by-value wrapper (`EdwardsPoint - EdwardsPoint`) takes its operands by value and
+  delegates to the core `&EdwardsPoint - &EdwardsPoint` subtraction.
 
-**Source**: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.Shared0EdwardsPoint.Insts.CoreOpsArithSubSharedAEdwardsPointEdwardsPoint
 
-/-
-natural language description:
-
-• Takes two EdwardsPoints `self` and `other`
-• Returns their difference as an EdwardsPoint via elliptic curve group subtraction
-• Implementation: converts `other` to projective niels form, performs subtraction
-  in completed point coordinates, and converts the result back to extended coordinates
-
-natural language specs:
-
-• The function always succeeds (no panic) for valid input Edwards points
-• The result is a valid Edwards point
-• The result represents the difference of the inputs (in the context of elliptic curve subtraction)
--/
-
-/-- **Spec and proof concerning
-`Shared0EdwardsPoint.Insts.CoreOpsArithSubSharedAEdwardsPointEdwardsPoint.sub`**:
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::sub`**
 • The function always succeeds (no panic) for valid inputs
 • The result is a valid Edwards point
 • The result represents the difference of the inputs (in the context of elliptic curve subtraction)
@@ -59,20 +46,19 @@ theorem sub_spec
 
 end curve25519_dalek.Shared0EdwardsPoint.Insts.CoreOpsArithSubSharedAEdwardsPointEdwardsPoint
 
-/-! ## Wrapper: `EdwardsPoint - EdwardsPoint` -/
-
 namespace curve25519_dalek.edwards.EdwardsPoint.Insts.CoreOpsArithSubEdwardsPointEdwardsPoint
 
-/-- **Spec and proof concerning
-`edwards.EdwardsPoint.Insts.CoreOpsArithSubEdwardsPointEdwardsPoint.sub`**:
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::sub`**
 • The function always succeeds (no panic) for valid inputs
 • The result is a valid Edwards point
-• The result represents the difference of the inputs
+• The result represents the difference of the inputs (in the context of elliptic curve subtraction)
 -/
 @[step]
-theorem sub_spec (self other : EdwardsPoint)
-    (h_self_valid : self.IsValid) (h_other_valid : other.IsValid) :
-    sub self other ⦃ result =>
+theorem sub_spec
+    (self other : EdwardsPoint)
+    (h_self_valid : self.IsValid)
+    (h_other_valid : other.IsValid) :
+    sub self other ⦃ (result : EdwardsPoint) =>
       result.IsValid ∧
       result.toPoint = self.toPoint - other.toPoint ⦄ := by
   unfold sub

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/ToAffine.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/ToAffine.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2025 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus Dablander
+Authors: Markus Dablander, Alessandro D'Angelo
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
@@ -9,67 +9,40 @@ import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Field.FieldElement51.Invert
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
 
-/-! # Spec Theorem for `EdwardsPoint::to_affine`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::to_affine`
 
-Specification and proof for `EdwardsPoint::to_affine`.
+Converts an `EdwardsPoint` from extended twisted Edwards coordinates `(X, Y, Z, T)` to
+affine coordinates `(x, y)` by dehomogenizing:
 
-This function converts an EdwardsPoint from extended twisted Edwards coordinates (X, Y, Z, T)
-to affine coordinates (x, y) by dehomogenizing: x = X/Z, y = Y/Z.
+- `x ≡ X / Z ≡ X * Z⁻¹ (mod p)`
+- `y ≡ Y / Z ≡ Y * Z⁻¹ (mod p)`
 
-Two specs are exposed:
-- `to_affine_spec'` — operational form. Requires only limb bounds (`< 2^54`) and gives
-  raw modular equalities + output bounds. Handles the degenerate `Z ≡ 0` case explicitly.
-  Not tagged `@[step]` — used internally by `to_affine_spec`.
-- `to_affine_spec` — math-bridged form. Requires `e.IsValid` and gives the clean
-  postcondition `result.IsValid ∧ result.toPoint = self.toPoint` in `Point Ed25519`.
-  Tagged `@[step]` — preferred form for chaining in downstream proofs.
+Special case: when `Z ≡ 0 (mod p)` (a point at infinity in projective coordinates), since
+`0.invert() = 0` in this implementation, the result is `(x, y) ≡ (0, 0) (mod p)`. In
+practice, valid `EdwardsPoint`s have `Z ≢ 0 (mod p)`.
 
-**Source**: curve25519-dalek/src/edwards.rs
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-open Edwards
-open curve25519_dalek.backend.serial.u64.field
+open Edwards curve25519_dalek.backend.serial.u64.field
 namespace curve25519_dalek.edwards.EdwardsPoint
 
-/-
-natural language description:
-
-• Converts an EdwardsPoint from extended twisted Edwards coordinates (X, Y, Z, T)
-to affine coordinates (x, y), where:
-  - x ≡ X/Z ≡ X * Z^(-1) (mod p)
-  - y ≡ Y/Z ≡ Y * Z^(-1) (mod p)
-
-• Special case: when Z ≡ 0 (mod p) (a point at infinity in projective coordinates),
-  since 0.invert() = 0 in this implementation, the result will be x ≡ 0, y ≡ 0 (mod p).
-  However, in practice, valid EdwardsPoints should have Z ≢ 0 (mod p).
-
-natural language specs (operational form `to_affine_spec'`):
-
-• The function always succeeds (no panic) when input limbs satisfy bounds
-• For the input Edwards point (X, Y, Z, T), it holds for the resulting AffinePoint:
-  - If Z ≢ 0 (mod p): x * Z ≡ X (mod p) and y * Z ≡ Y (mod p)
-  - If Z ≡ 0 (mod p): x ≡ 0 (mod p) and y ≡ 0 (mod p)
-where p = 2^255 - 19
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::to_affine`**
+• The function always succeeds (no panic) when the input limbs satisfy `< 2 ^ 54`
+• If `Z ≡ 0 (mod p)`: `x ≡ 0 (mod p)` and `y ≡ 0 (mod p)`
+• If `Z ≢ 0 (mod p)`: `x * Z ≡ X (mod p)` and `y * Z ≡ Y (mod p)`
+• Output limb bounds: every limb of `ap.x` and `ap.y` is `< 2 ^ 52`
 -/
-
-/-- **Operational spec for `edwards.EdwardsPoint.to_affine`**:
-- No panic (always returns successfully)
-- For the input Edwards point (X, Y, Z, T), the resulting AffinePoint has coordinates:
-  - If Z ≡ 0 (mod p): x ≡ 0 (mod p) and y ≡ 0 (mod p)
-  - If Z ≢ 0 (mod p): x * Z ≡ X (mod p) and y * Z ≡ Y (mod p)
-- Output limb bounds: `< 2^52` on `ap.x` and `ap.y`
-
-This is the primitive form. Use `to_affine_spec` (math-bridged) in downstream proofs.
--/
-theorem to_affine_spec' (e : EdwardsPoint)
-    (hX : ∀ i < 5, e.X[i]!.val < 2 ^ 54)
-    (hY : ∀ i < 5, e.Y[i]!.val < 2 ^ 54)
-    (hZ : ∀ i < 5, e.Z[i]!.val < 2 ^ 54) :
-    to_affine e ⦃ ap =>
-      let X := Field51_as_Nat e.X
-      let Y := Field51_as_Nat e.Y
-      let Z := Field51_as_Nat e.Z
+theorem to_affine_spec' (self : EdwardsPoint)
+    (hX : ∀ i < 5, self.X[i]!.val < 2 ^ 54)
+    (hY : ∀ i < 5, self.Y[i]!.val < 2 ^ 54)
+    (hZ : ∀ i < 5, self.Z[i]!.val < 2 ^ 54) :
+    to_affine self ⦃ (ap : affine.AffinePoint) =>
+      let X := Field51_as_Nat self.X
+      let Y := Field51_as_Nat self.Y
+      let Z := Field51_as_Nat self.Z
       let x := Field51_as_Nat ap.x
       let y := Field51_as_Nat ap.y
       (if Z % p = 0 then
@@ -77,84 +50,81 @@ theorem to_affine_spec' (e : EdwardsPoint)
       else
         (x * Z) % p = X % p ∧
         (y * Z) % p = Y % p) ∧
-        (∀ i < 5, ap.x[i]!.val < 2 ^ 52) ∧
-        (∀ i < 5, ap.y[i]!.val < 2 ^ 52) ⦄ := by
-    unfold to_affine
-    step as ⟨Z_inv, h_inv_nonzero, h_inv_zero, h_inv_bounds⟩  -- invert e.Z
-    step as ⟨x, hx_mod, hx_bounds⟩  -- mul e.X Z_inv
-    step as ⟨y, hy_mod, hy_bounds⟩  -- mul e.Y Z_inv
-    constructor
-    · split_ifs with h_Z
-      · -- Z ≡ 0 case
-        have h_val : Field51_as_Nat Z_inv % p = 0 := h_inv_zero h_Z
-        rw [Nat.ModEq] at hx_mod hy_mod
-        constructor
-        · rw [hx_mod, Nat.mul_mod, h_val, mul_zero, Nat.zero_mod]
-        · rw [hy_mod, Nat.mul_mod, h_val, mul_zero, Nat.zero_mod]
-      · -- Z ≢ 0 case
-        have h_val : (Field51_as_Nat Z_inv % p * (Field51_as_Nat e.Z % p)) % p = 1 :=
-          h_inv_nonzero h_Z
-        rw [Nat.mul_mod] at h_val
-        rw [Nat.ModEq] at hx_mod hy_mod
-        constructor
-        · rw [Nat.mul_mod, hx_mod]
-          simp only [Nat.mul_mod_mod, Nat.mod_mul_mod, mul_assoc]
-          simp only [dvd_refl, Nat.mod_mod_of_dvd, Nat.mul_mod_mod, Nat.mod_mul_mod] at h_val
-          simp [Nat.mul_mod, h_val]
-        · rw [Nat.mul_mod, hy_mod]
-          simp only [Nat.mul_mod_mod, Nat.mod_mul_mod, mul_assoc]
-          simp only [dvd_refl, Nat.mod_mod_of_dvd, Nat.mul_mod_mod, Nat.mod_mul_mod] at h_val
-          simp [Nat.mul_mod, h_val]
-    · constructor
-      · intro i hi; have := hx_bounds i hi; omega
-      · intro i hi; have := hy_bounds i hi; omega
+      (∀ i < 5, ap.x[i]!.val < 2 ^ 52) ∧
+      (∀ i < 5, ap.y[i]!.val < 2 ^ 52) ⦄ := by
+  unfold to_affine
+  step as ⟨Z_inv, h_inv_nonzero, h_inv_zero, h_inv_bounds⟩ -- invert self.Z
+  step as ⟨x, hx_mod, hx_bounds⟩ -- mul self.X Z_inv
+  step as ⟨y, hy_mod, hy_bounds⟩ -- mul self.Y Z_inv
+  constructor
+  · split_ifs with h_Z
+    · -- Z ≡ 0 case
+      have h_val : Field51_as_Nat Z_inv % p = 0 := h_inv_zero h_Z
+      rw [Nat.ModEq] at hx_mod hy_mod
+      constructor
+      · rw [hx_mod, Nat.mul_mod, h_val, mul_zero, Nat.zero_mod]
+      · rw [hy_mod, Nat.mul_mod, h_val, mul_zero, Nat.zero_mod]
+    · -- Z ≢ 0 case
+      have h_val : (Field51_as_Nat Z_inv % p * (Field51_as_Nat self.Z % p)) % p = 1 :=
+        h_inv_nonzero h_Z
+      rw [Nat.mul_mod] at h_val
+      rw [Nat.ModEq] at hx_mod hy_mod
+      constructor
+      · rw [Nat.mul_mod, hx_mod]
+        simp only [Nat.mul_mod_mod, Nat.mod_mul_mod, mul_assoc]
+        simp only [dvd_refl, Nat.mod_mod_of_dvd, Nat.mul_mod_mod, Nat.mod_mul_mod] at h_val
+        simp [Nat.mul_mod, h_val]
+      · rw [Nat.mul_mod, hy_mod]
+        simp only [Nat.mul_mod_mod, Nat.mod_mul_mod, mul_assoc]
+        simp only [dvd_refl, Nat.mod_mod_of_dvd, Nat.mul_mod_mod, Nat.mod_mul_mod] at h_val
+        simp [Nat.mul_mod, h_val]
+  · constructor
+    · intro i hi; have := hx_bounds i hi; omega
+    · intro i hi; have := hy_bounds i hi; omega
 
-/-- **Spec and proof concerning `edwards.EdwardsPoint.to_affine`** (math-bridged):
-- Requires `self.IsValid` (limbs `< 2^53`, `Z ≠ 0`, extended relation, curve equation).
-- Ensures `result.IsValid` (the affine point satisfies the curve equation).
-- Math bridge: `result.toPoint = self.toPoint` in `Point Ed25519`.
-
-Wraps the operational `to_affine_spec'` and lifts its Nat-modular postconditions to
-the abstract `Point Ed25519` group.
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::to_affine`**
+• The function always succeeds (no panic) for a valid `EdwardsPoint`
+• The result is a valid affine point
+• The result represents the same abstract point: `result.toPoint = self.toPoint`
 -/
 @[step]
-theorem to_affine_spec (e : EdwardsPoint) (hself : e.IsValid) :
-    to_affine e ⦃ ap =>
+theorem to_affine_spec (self : EdwardsPoint) (hself : self.IsValid) :
+    to_affine self ⦃ (ap : affine.AffinePoint) =>
       ap.IsValid ∧
-      ap.toPoint = e.toPoint ⦄ := by
+      ap.toPoint = self.toPoint ⦄ := by
   -- Derive < 2^54 bounds from IsValid (which gives < 2^53)
-  have hX : ∀ i < 5, e.X[i]!.val < 2 ^ 54 :=
+  have hX : ∀ i < 5, self.X[i]!.val < 2 ^ 54 :=
     fun i hi => by have := hself.X_bounds i hi; omega
-  have hY : ∀ i < 5, e.Y[i]!.val < 2 ^ 54 :=
+  have hY : ∀ i < 5, self.Y[i]!.val < 2 ^ 54 :=
     fun i hi => by have := hself.Y_bounds i hi; omega
-  have hZ_bnd : ∀ i < 5, e.Z[i]!.val < 2 ^ 54 :=
+  have hZ_bnd : ∀ i < 5, self.Z[i]!.val < 2 ^ 54 :=
     fun i hi => by have := hself.Z_bounds i hi; omega
   -- Z's Nat representation isn't ≡ 0 mod p (from `Z.toField ≠ 0`)
-  have hZ_mod_ne : Field51_as_Nat e.Z % p ≠ 0 := by
+  have hZ_mod_ne : Field51_as_Nat self.Z % p ≠ 0 := by
     intro h
     apply hself.Z_ne_zero
     unfold FieldElement51.toField
     exact lift_mod_eq _ _ (by simpa [Nat.zero_mod] using h)
   -- Apply the operational spec and weaken
-  apply WP.spec_mono (to_affine_spec' e hX hY hZ_bnd)
+  apply WP.spec_mono (to_affine_spec' self hX hY hZ_bnd)
   intro ap ⟨h_branch, h_x_bnd, h_y_bnd⟩
   -- Z ≢ 0 branch is the only reachable one
   rw [if_neg hZ_mod_ne] at h_branch
   obtain ⟨hxZ_mod, hyZ_mod⟩ := h_branch
   -- Lift modular equalities to ZMod
-  have hxZ_field : ap.x.toField * e.Z.toField = e.X.toField := by
+  have hxZ_field : ap.x.toField * self.Z.toField = self.X.toField := by
     unfold FieldElement51.toField
     have h := lift_mod_eq _ _ hxZ_mod
     push_cast at h; exact h
-  have hyZ_field : ap.y.toField * e.Z.toField = e.Y.toField := by
+  have hyZ_field : ap.y.toField * self.Z.toField = self.Y.toField := by
     unfold FieldElement51.toField
     have h := lift_mod_eq _ _ hyZ_mod
     push_cast at h; exact h
-  have hZ_ne : e.Z.toField ≠ 0 := hself.Z_ne_zero
+  have hZ_ne : self.Z.toField ≠ 0 := hself.Z_ne_zero
   -- Derive division forms
-  have hx_div : ap.x.toField = e.X.toField / e.Z.toField := by
+  have hx_div : ap.x.toField = self.X.toField / self.Z.toField := by
     field_simp; exact hxZ_field
-  have hy_div : ap.y.toField = e.Y.toField / e.Z.toField := by
+  have hy_div : ap.y.toField = self.Y.toField / self.Z.toField := by
     field_simp; exact hyZ_field
   -- Construct ap.IsValid
   have h_ap_curve :
@@ -163,8 +133,8 @@ theorem to_affine_spec (e : EdwardsPoint) (hself : e.IsValid) :
     rw [hx_div, hy_div]
     have hcurve := hself.on_curve
     simp only at hcurve
-    have hz2 : e.Z.toField ^ 2 ≠ 0 := pow_ne_zero 2 hZ_ne
-    have hz4 : e.Z.toField ^ 4 ≠ 0 := pow_ne_zero 4 hZ_ne
+    have hz2 : self.Z.toField ^ 2 ≠ 0 := pow_ne_zero 2 hZ_ne
+    have hz4 : self.Z.toField ^ 4 ≠ 0 := pow_ne_zero 4 hZ_ne
     simp only [Ed25519] at hcurve ⊢
     simp only [div_pow]
     field_simp
@@ -174,8 +144,8 @@ theorem to_affine_spec (e : EdwardsPoint) (hself : e.IsValid) :
     y_valid := fun i hi => by have := h_y_bnd i hi; omega
     on_curve := h_ap_curve }
   refine ⟨h_ap_valid, ?_⟩
-  -- Show ap.toPoint = e.toPoint
-  unfold edwards.affine.AffinePoint.toPoint EdwardsPoint.toPoint
+  -- Show ap.toPoint = self.toPoint
+  unfold affine.AffinePoint.toPoint EdwardsPoint.toPoint
   rw [dif_pos h_ap_valid, dif_pos hself]
   unfold EdwardsPoint.toPoint'
   ext

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/ToMontgomery.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/ToMontgomery.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus Dablander
+Authors: Markus Dablander, Hoang Le Truong
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Aux
@@ -13,82 +13,27 @@ import Curve25519Dalek.Specs.Field.FieldElement51.Invert
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ToBytes
 import Curve25519Dalek.Math.Montgomery.Representation
-/-! # Spec Theorem for `EdwardsPoint::to_montgomery`
 
-Specification and proof for `EdwardsPoint::to_montgomery`.
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::to_montgomery`
 
-This function converts an EdwardsPoint from the twisted Edwards curve to the
-corresponding MontgomeryPoint (only the u-coordinate) on the Montgomery curve,
+This function converts an EdwardsPoint from extended twisted Edwards coordinates
+`(X, Y, Z, T)` to a MontgomeryPoint (u-coordinate only) on the Montgomery curve,
 using the birational map
-u = (1+y)/(1-y) = (Z+Y)/(Z-Y).
 
-**Source**: curve25519-dalek/src/edwards.rs
+  u ≡ (1 + y) / (1 - y) ≡ (Z + Y) / (Z - Y)  (mod p),  where p = 2 ^ 255 - 19.
+
+Special case: when `Y = Z` (affine `y = 1`, the identity point on the Edwards
+curve), the denominator is zero. Since `0.invert() = 0` in this implementation,
+the result is `u = 0`. The output `u` is represented as a `U8x32` array (a type
+alias for `MontgomeryPoint`).
+
+Source: "curve25519-dalek/src/edwards.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open Montgomery
 namespace curve25519_dalek.edwards.EdwardsPoint
-
-/-
-natural language description:
-
-• Converts an EdwardsPoint from extended twisted Edwards coordinates (X, Y, Z, T)
-to a MontgomeryPoint (u-coordinate only), using the birational map:
-  - u ≡ (1+y)/(1-y) ≡ (Z+Y)/(Z-Y) (mod p)
-
-• Special case: when Y = Z (affine y = 1, the identity point on Edwards curve),
-  the denominator is zero. Since 0.invert() = 0 in this implementation,
-  this yields u = 0.
-
-• The output u is represented as an U8x32 array (a type alias for MontgomeryPoint)
-
-natural language specs:
-
-• The function always succeeds (no panic)
-• For the input Edwards point (X, Y, Z, T), the resulting MontgomeryPoint has u-coordinate:
-  - If Z ≢ Y (mod p): u ≡ (Z+Y) * (Z-Y)^(-1) (mod p)
-  - If Z ≡ Y (mod p): u ≡ 0 (mod p)
-where p = 2^255 - 19
--/
-
-/-!
-## Key proof steps for `to_montgomery_birational_eq`
-
-The proof establishes `fromEdwards e.toPoint = MontgomeryPoint.mkPoint a` given:
-1. Bounds on the Edwards point limbs (h_Y_bounds, h_Z_bounds)
-2. An arithmetic relationship (h_arith) between the Field51 limb representations of
-   Y, Z and the byte representation of a.
-
-The proof proceeds by:
-
-
-**Step 2 – Identify u-coordinates.**
-Show that the u-coordinate stored in `MontgomeryPoint.mkPoint a` (namely
-`(U8x32_as_Field a)`) equals
-`(1 + e.toPoint.y) / (1 - e.toPoint.y)`, the x-coordinate produced by `fromEdwards`.
-
-**Step 3 – Identify v-coordinates.**
-Both definitions choose a v satisfying `v^2 = u^3 + A*u^2 + u`:
-- `fromEdwards` uses `v_ed = roots_B * (1 + y) / ((1 - y) * x)`.
-- `u_affine_toPoint` uses `v_mont = (sqrt_checked (v_squared u)).1 = abs_edwards r`
-  where `r^2 = v_squared u`.
-Since `v_ed` is itself a square root of `v_squared u` (proved by `on_MontgomeryCurves`),
-and `abs_edwards` picks the canonical (even-parity) square root, one shows
-`v_ed = ±v_mont`. Equality (rather than negation) requires a parity argument
-relating `roots_B` to the canonical root choice.
-
-**Step 4 – Handle degenerate cases.**
-- If `e.IsValid` is false, `e.toPoint = 0` and `fromEdwards 0 = 0`.
-  The h_arith "if" branch then forces u ≡ 0, so `mkPoint a = T_point`.
-  (Note: `0 ≠ T_point` as Weierstrass affine points; the identity case requires
-  the additional hypothesis that the Edwards point is not the group identity,
-  which is guaranteed by the valid-point invariant in practice.)
-- If `e.toPoint.x = 0` (2-torsion), `fromEdwards` returns `T_point` and
-  `mkPoint a` also returns `T_point` (since u = 0 there).
-
-The full proof requires several supporting lemmas about `sqrt_checked`, `abs_edwards`,
-`roots_B`, and the interaction of `% 2^255` with the field embedding.
--/
 
 lemma mkPoint_u_zero (a : montgomery.MontgomeryPoint)
     (h : (U8x32_as_Field a) = 0) :
@@ -101,9 +46,9 @@ private lemma v_coord_birational_match
     (e : Edwards.Point Edwards.Ed25519)
     (hy_ne_1 : e.y ≠ 1) (hx_ne_0 : e.x ≠ 0)
     (h_sqrt_true :
-      (curve25519_dalek.math.sqrt_checked
+      (math.sqrt_checked
         (v_squared ((1 + e.y) / (1 - e.y)))).2 = true) :
-    (curve25519_dalek.math.sqrt_checked
+    (math.sqrt_checked
       (v_squared ((1 + e.y) / (1 - e.y)))).1 =
     math.abs_edwards (Curve25519.roots_B * (1 + e.y) / ((1 - e.y) * e.x)) := by
   set u := (1 + e.y) / (1 - e.y) with hu_def
@@ -113,28 +58,28 @@ private lemma v_coord_birational_match
     simp only at h
     simp only [v_squared]
     exact h
-  have h_r_sq : (curve25519_dalek.math.sqrt_checked (v_squared u)).1 ^ 2 = v_squared u :=
-    curve25519_dalek.math.sqrt_checked_spec (v_squared u)
-      (Prod.mk.eta (p := curve25519_dalek.math.sqrt_checked (v_squared u))).symm h_sqrt_true
-  have h_abs_eq : curve25519_dalek.math.abs_edwards
-        (curve25519_dalek.math.sqrt_checked (v_squared u)).1 =
-      curve25519_dalek.math.abs_edwards v_E :=
-    curve25519_dalek.math.abs_edwards_eq_of_sq_eq (by rw [h_r_sq, h_v_sq])
+  have h_r_sq : (math.sqrt_checked (v_squared u)).1 ^ 2 = v_squared u :=
+    math.sqrt_checked_spec (v_squared u)
+      (Prod.mk.eta (p := math.sqrt_checked (v_squared u))).symm h_sqrt_true
+  have h_abs_eq : math.abs_edwards
+        (math.sqrt_checked (v_squared u)).1 =
+      math.abs_edwards v_E :=
+    math.abs_edwards_eq_of_sq_eq (by rw [h_r_sq, h_v_sq])
   have h_is_sq : IsSquare (v_squared u) :=
-    (curve25519_dalek.math.sqrt_checked_iff_isSquare (v_squared u)
-      (Prod.mk.eta (p := curve25519_dalek.math.sqrt_checked (v_squared u))).symm).mp h_sqrt_true
-  have h_r_unfold : (curve25519_dalek.math.sqrt_checked (v_squared u)).1 =
-      curve25519_dalek.math.abs_edwards (Classical.choose h_is_sq) := by
-    unfold curve25519_dalek.math.sqrt_checked
+    (math.sqrt_checked_iff_isSquare (v_squared u)
+      (Prod.mk.eta (p := math.sqrt_checked (v_squared u))).symm).mp h_sqrt_true
+  have h_r_unfold : (math.sqrt_checked (v_squared u)).1 =
+      math.abs_edwards (Classical.choose h_is_sq) := by
+    unfold math.sqrt_checked
     rw [dif_pos h_is_sq]
-  have h_r_not_neg : curve25519_dalek.math.is_negative
-      (curve25519_dalek.math.sqrt_checked (v_squared u)).1 = false := by
+  have h_r_not_neg : math.is_negative
+      (math.sqrt_checked (v_squared u)).1 = false := by
     rw [h_r_unfold]
-    exact curve25519_dalek.math.is_negative_abs_edwards _
-  have h_r_canon : curve25519_dalek.math.abs_edwards
-        (curve25519_dalek.math.sqrt_checked (v_squared u)).1 =
-      (curve25519_dalek.math.sqrt_checked (v_squared u)).1 := by
-    unfold curve25519_dalek.math.abs_edwards
+    exact math.is_negative_abs_edwards _
+  have h_r_canon : math.abs_edwards
+        (math.sqrt_checked (v_squared u)).1 =
+      (math.sqrt_checked (v_squared u)).1 := by
+    unfold math.abs_edwards
     rw [h_r_not_neg]
     simp
   simp_all
@@ -191,9 +136,7 @@ private lemma v_squared_isSquare_of_nonsingular
     rw [← sq]
     grind⟩
 
-theorem modEq_zero_iff (a n : ℕ) : a ≡ 0 [MOD n] ↔  a % n = 0 := by simp [Nat.ModEq]
-
-lemma abs_T_point : abs_montgomery T_point = T_point:= by
+lemma abs_T_point : abs_montgomery T_point = T_point := by
   unfold T_point abs_montgomery
   simp
 
@@ -204,17 +147,17 @@ theorem to_montgomery_birational_zero
     (hzy : Field51_as_Nat e.Z % p = Field51_as_Nat e.Y % p) :
     fromEdwards (n • e.toPoint) = 0 := by
   have hZY_eq : (Field51_as_Nat e.Z : CurveField) = Field51_as_Nat e.Y :=
-      (Montgomery.lift_mod_eq_iff (Field51_as_Nat e.Z) (Field51_as_Nat e.Y)).mp hzy
+      (lift_mod_eq_iff (Field51_as_Nat e.Z) (Field51_as_Nat e.Y)).mp hzy
   have he_zero : e.toPoint = 0 := by
     unfold EdwardsPoint.toPoint
     simp only [hvalid, ↓reduceDIte]
     apply zeroY
     have hy_val := (EdwardsPoint.toPoint_of_isValid hvalid).2
     simp only [toPoint, hvalid, ↓reduceDIte] at hy_val
-    unfold curve25519_dalek.backend.serial.u64.field.FieldElement51.toField at hy_val
-    have:= hvalid.Z_ne_zero
-    unfold curve25519_dalek.backend.serial.u64.field.FieldElement51.toField at this
-    rw [hy_val, ← hZY_eq, div_self this ]
+    unfold backend.serial.u64.field.FieldElement51.toField at hy_val
+    have := hvalid.Z_ne_zero
+    unfold backend.serial.u64.field.FieldElement51.toField at this
+    rw [hy_val, ← hZY_eq, div_self this]
   rw [he_zero, smul_zero, map_zero]
 
 theorem to_montgomery_birational_eq
@@ -235,11 +178,11 @@ theorem to_montgomery_birational_eq
   simp only [hzy, ↓reduceIte] at h_arith
   have hne : (Field51_as_Nat e.Z : CurveField) ≠ Field51_as_Nat e.Y := by
     intro h
-    exact hzy ((Montgomery.lift_mod_eq_iff _ _).mpr h)
+    exact hzy ((lift_mod_eq_iff _ _).mpr h)
   have h_field : (U8x32_as_Nat a : CurveField) * Field51_as_Nat e.Z =
         (U8x32_as_Nat a : CurveField) * Field51_as_Nat e.Y +
         ((Field51_as_Nat e.Z : CurveField) + Field51_as_Nat e.Y) := by
-    have hme := (Montgomery.lift_mod_eq_iff
+    have hme := (lift_mod_eq_iff
         (U8x32_as_Nat a * Field51_as_Nat e.Z)
         (U8x32_as_Nat a * Field51_as_Nat e.Y +
           (Field51_as_Nat e.Z + Field51_as_Nat e.Y))).mp h_arith
@@ -252,8 +195,8 @@ theorem to_montgomery_birational_eq
       rw [eq_div_iff hZmY_ne]
       linear_combination h_field
   have h_u_0_eq : (U8x32_as_Field a) =
-        (((Field51_as_Nat e.Z):CurveField) + Field51_as_Nat e.Y) /
-        (((Field51_as_Nat e.Z):CurveField) - Field51_as_Nat e.Y) := by
+        (((Field51_as_Nat e.Z) : CurveField) + Field51_as_Nat e.Y) /
+        (((Field51_as_Nat e.Z) : CurveField) - Field51_as_Nat e.Y) := by
       rw [U8x32_as_Field_eq_cast a, h_u_eq]
   have he_y := (EdwardsPoint.toPoint_of_isValid hvalid).2
   have hZ_ne : (Field51_as_Nat e.Z : CurveField) ≠ 0 := hvalid.Z_ne_zero
@@ -261,12 +204,12 @@ theorem to_montgomery_birational_eq
     rw [he_y]
     intro h_eq
     apply hne
-    unfold curve25519_dalek.backend.serial.u64.field.FieldElement51.toField at h_eq
+    unfold backend.serial.u64.field.FieldElement51.toField at h_eq
     field_simp at h_eq
     exact h_eq.symm
   have hu_bira : (1 + e.toPoint.y) / (1 - e.toPoint.y) = (U8x32_as_Field a) := by
     rw [h_u_0_eq, he_y]
-    unfold curve25519_dalek.backend.serial.u64.field.FieldElement51.toField
+    unfold backend.serial.u64.field.FieldElement51.toField
     field_simp [hZ_ne]
   by_cases hx : e.toPoint.x = 0
   · unfold fromEdwards
@@ -284,11 +227,11 @@ theorem to_montgomery_birational_eq
       exact birational_u_ne_zero_of_x_ne_zero e.toPoint hy_ne_1 hx
     have h_is_sq : IsSquare (v_squared (U8x32_as_Field a)) :=
           v_squared_isSquare_of_nonsingular e.toPoint a hy_ne_1 hx hu_bira
-    have h_sqrt_true : (curve25519_dalek.math.sqrt_checked
+    have h_sqrt_true : (math.sqrt_checked
               (v_squared (U8x32_as_Field a))).2 = true :=
-          (curve25519_dalek.math.sqrt_checked_iff_isSquare
+          (math.sqrt_checked_iff_isSquare
             (v_squared (U8x32_as_Field a))
-            (Prod.mk.eta (p := curve25519_dalek.math.sqrt_checked
+            (Prod.mk.eta (p := math.sqrt_checked
               (v_squared (U8x32_as_Field a)))).symm).mpr h_is_sq
     simp only [MontgomeryPoint.mkPoint, MontgomeryPoint.u_affine_toPoint, h_sqrt_true,
       Bool.not_true, hu_0_ne, beq_iff_eq]
@@ -296,37 +239,48 @@ theorem to_montgomery_birational_eq
     simp only [Bool.false_eq_true, ↓reduceDIte]
     apply abs_eq_some
     · exact hu_bira
-    · have :=v_coord_birational_match e.toPoint hy_ne_1 hx
+    · have := v_coord_birational_match e.toPoint hy_ne_1 hx
             (by rw [hu_bira]; exact h_sqrt_true)
-      rw[hu_bira]  at this
-      rw[this]
+      rw [hu_bira] at this
+      rw [this]
 
+/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::to_montgomery`**
+• The function always succeeds (no panic) for any valid input Edwards point
+• In the degenerate case `Z ≡ Y (mod p)`, the output u-coordinate satisfies
+  `u ≡ 0 (mod p)`
+• In the same degenerate case, `fromEdwards (n • self.toPoint) = 0` for every natural number `n`
+• In the generic case `Z ≢ Y (mod p)`, the output u-coordinate satisfies
+  `u * Z ≡ u * Y + (Z + Y) (mod p)`, equivalently `u ≡ (Z + Y) / (Z - Y) (mod p)`
+• In the generic case, `MontgomeryPoint.mkPoint mp` equals
+  `abs_montgomery (fromEdwards self.toPoint)`
+-/
 @[step]
-theorem to_montgomery_spec (e : EdwardsPoint)
-    (hvalid : e.IsValid)
-    (h_Y_bounds : ∀ i < 5, e.Y[i]!.val < 2 ^ 53) (h_Z_bounds : ∀ i < 5, e.Z[i]!.val < 2 ^ 53) :
-    to_montgomery e ⦃ mp =>
-      let Y := Field51_as_Nat e.Y
-      let Z := Field51_as_Nat e.Z
+theorem to_montgomery_spec (self : EdwardsPoint)
+    (hvalid : self.IsValid)
+    (h_Y_bounds : ∀ i < 5, self.Y[i]!.val < 2 ^ 53)
+    (h_Z_bounds : ∀ i < 5, self.Z[i]!.val < 2 ^ 53) :
+    to_montgomery self ⦃ (mp : montgomery.MontgomeryPoint) =>
+      let Y := Field51_as_Nat self.Y
+      let Z := Field51_as_Nat self.Z
       let u := U8x32_as_Nat mp
       if Z % p = Y % p then
-        u % p = 0 ∧ (∀ n : ℕ, fromEdwards (n • e.toPoint) = 0)
+        u % p = 0 ∧ (∀ n : ℕ, fromEdwards (n • self.toPoint) = 0)
       else
-      ((u * Z) % p = (u * Y + (Z + Y)) % p) ∧
-      ( abs_montgomery (fromEdwards (e.toPoint)) = (MontgomeryPoint.mkPoint mp)) ⦄ := by
+        ((u * Z) % p = (u * Y + (Z + Y)) % p) ∧
+        abs_montgomery (fromEdwards self.toPoint) = MontgomeryPoint.mkPoint mp ⦄ := by
   unfold to_montgomery
   (step*; try grind)
-  · have h_arith : (let Y := Field51_as_Nat e.Y; let Z := Field51_as_Nat e.Z;
+  · have h_arith : (let Y := Field51_as_Nat self.Y; let Z := Field51_as_Nat self.Z;
         let u := U8x32_as_Nat a;
         if Z % p = Y % p then u % p = 0
-        else  (u * Z) % p = (u * Y + (Z + Y)) % p) := by
+        else (u * Z) % p = (u * Y + (Z + Y)) % p) := by
       simp only
       split_ifs
       · rename_i h_zy
         have h_W_zero : Field51_as_Nat W % p = 0 := by
           rw [h_zy, ← Nat.ModEq] at W_post2
-          conv_rhs at W_post2 => rw [← Nat.zero_add (Field51_as_Nat e.Y)]
-          exact Nat.ModEq.add_right_cancel' (Field51_as_Nat e.Y) W_post2
+          conv_rhs at W_post2 => rw [← Nat.zero_add (Field51_as_Nat self.Y)]
+          exact Nat.ModEq.add_right_cancel' (Field51_as_Nat self.Y) W_post2
         rw [a_post1, u_post1, Nat.mul_mod, fe_post2 h_W_zero, mul_zero, Nat.zero_mod]
       · rename_i h_zy
         have h_W_neq_zero : Field51_as_Nat W % p ≠ 0 := by
@@ -334,9 +288,9 @@ theorem to_montgomery_spec (e : EdwardsPoint)
           rw [Nat.add_mod, h_contra, Nat.zero_add, Nat.mod_mod] at W_post2
           exact h_zy W_post2.symm
         have h_W_inv := fe_post1 h_W_neq_zero
-        simp at h_W_inv
+        simp only [Nat.mul_mod_mod, Nat.mod_mul_mod] at h_W_inv
         ring_nf at h_W_inv
-        have h_U_eq : Field51_as_Nat U = Field51_as_Nat e.Y + Field51_as_Nat e.Z := by
+        have h_U_eq : Field51_as_Nat U = Field51_as_Nat self.Y + Field51_as_Nat self.Z := by
           unfold Field51_as_Nat
           rw [← Finset.sum_add_distrib]
           apply Finset.sum_congr rfl
@@ -344,7 +298,7 @@ theorem to_montgomery_spec (e : EdwardsPoint)
           rw [U_post1 i (Finset.mem_range.mp hi)]
           ring
         have h_elim : U8x32_as_Nat a * Field51_as_Nat W ≡
-          Field51_as_Nat e.Y + Field51_as_Nat e.Z [MOD p] := by
+          Field51_as_Nat self.Y + Field51_as_Nat self.Z [MOD p] := by
           calc
             U8x32_as_Nat a * Field51_as_Nat W ≡
                 Field51_as_Nat u * Field51_as_Nat W [MOD p] := by
@@ -355,18 +309,19 @@ theorem to_montgomery_spec (e : EdwardsPoint)
               rw [Nat.mul_assoc]
               simpa using @Nat.ModEq.mul_left p (Field51_as_Nat fe *
               Field51_as_Nat W) 1 (Field51_as_Nat U) h_W_inv
-            _ ≡ Field51_as_Nat e.Y + Field51_as_Nat e.Z [MOD p] := by
+            _ ≡ Field51_as_Nat self.Y + Field51_as_Nat self.Z [MOD p] := by
                   unfold Nat.ModEq; simp only [h_U_eq]
         rw [Nat.mul_mod, ← W_post2, Nat.add_mod, ← Nat.mul_mod, Nat.mul_add, ← Nat.ModEq]
         ring_nf
         have h_sum : U8x32_as_Nat a * (Field51_as_Nat W % p) +
-            U8x32_as_Nat a * (Field51_as_Nat e.Y % p)
-            ≡ U8x32_as_Nat a * Field51_as_Nat W + U8x32_as_Nat a * Field51_as_Nat e.Y [MOD p] :=
+            U8x32_as_Nat a * (Field51_as_Nat self.Y % p)
+            ≡ U8x32_as_Nat a * Field51_as_Nat W +
+                U8x32_as_Nat a * Field51_as_Nat self.Y [MOD p] :=
             (Nat.ModEq.mul_left (U8x32_as_Nat a) (Nat.mod_modEq (Field51_as_Nat W) p)).add
-            (Nat.ModEq.mul_left (U8x32_as_Nat a) (Nat.mod_modEq (Field51_as_Nat e.Y) p))
+            (Nat.ModEq.mul_left (U8x32_as_Nat a) (Nat.mod_modEq (Field51_as_Nat self.Y) p))
         refine h_sum.trans ?_
         rw [Nat.add_comm]
-        have h_full := Nat.ModEq.add_left (U8x32_as_Nat a * Field51_as_Nat e.Y) h_elim
+        have h_full := Nat.ModEq.add_left (U8x32_as_Nat a * Field51_as_Nat self.Y) h_elim
         grind
     split_ifs
     · rename_i h1
@@ -377,10 +332,10 @@ theorem to_montgomery_spec (e : EdwardsPoint)
         apply to_montgomery_birational_zero
         all_goals simp_all
     · rename_i h1
-      have h_arith1:= h_arith
+      have h_arith1 := h_arith
       simp only [h1, ↓reduceIte] at h_arith
       constructor
       · exact h_arith
-      · rw [ to_montgomery_birational_eq e a hvalid h_arith1 h1]
+      · rw [to_montgomery_birational_eq self a hvalid h_arith1 h1]
 
 end curve25519_dalek.edwards.EdwardsPoint

--- a/Curve25519Dalek/Specs/Edwards/EdwardsPoint/VartimeDoubleScalarMulBasepoint.lean
+++ b/Curve25519Dalek/Specs/Edwards/EdwardsPoint/VartimeDoubleScalarMulBasepoint.lean
@@ -6,13 +6,14 @@ Authors: Oliver Butterley, Alessandro D'Angelo, Liao Zhang
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 
-/-! # `EdwardsPoint::vartime_double_scalar_mul_basepoint`
+/-!
+# Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::vartime_double_scalar_mul_basepoint`
 
 Computes `[a]A + [b]B` in variable time, where `B` is the Ed25519 basepoint.
 Used by Ed25519 signature verification (the canonical caller is
 `ristretto::RistrettoPoint::vartime_double_scalar_mul_basepoint`, which delegates here).
 
-**Source**: `curve25519-dalek/src/edwards.rs:1037-1047`
+Source: "curve25519-dalek/src/edwards.rs"
 
 ## Status: cannot specify yet — function not extracted
 
@@ -42,25 +43,25 @@ backends (serial / AVX2 / AVX512) via runtime backend selection, which Aeneas ca
 ## Target spec shape (for when extraction is unblocked)
 
 The Verus port at `dalek-lite/curve25519-dalek/src/edwards.rs:2853-2869` specifies:
-- **Pre**: `is_well_formed_edwards_point(*A) ∧ scalar_as_nat(a) < 2^255 ∧ scalar_as_nat(b) < 2^255`
+- **Pre**: `is_well_formed_edwards_point(*A)` ∧
+  `scalar_as_nat(a) < 2^255` ∧ `scalar_as_nat(b) < 2^255`
 - **Post**: `result.IsValid` ∧
   `result.toPoint = (U8x32_as_Nat a.bytes) • A.toPoint`
   ` + (U8x32_as_Nat b.bytes) • Edwards.basepoint`
 
-Concretely, the future Lean theorem will read:
+Concretely, the future Lean theorem will likely read:
 ```
 @[step, externally_verified] -- proven in Verus
-theorem vartime_double_scalar_mul_basepoint_spec (a : scalar.Scalar) (A : edwards.EdwardsPoint)
+theorem vartime_double_scalar_mul_basepoint_spec (a : scalar.Scalar) (A : EdwardsPoint)
     (b : scalar.Scalar) (h_A_valid : A.IsValid)
     (h_a_canonical : U8x32_as_Nat a.bytes < 2 ^ 255)
     (h_b_canonical : U8x32_as_Nat b.bytes < 2 ^ 255) :
-    vartime_double_scalar_mul_basepoint a A b ⦃ result =>
+    vartime_double_scalar_mul_basepoint a A b ⦃ (result : EdwardsPoint) =>
       result.IsValid ∧
       result.toPoint = (U8x32_as_Nat a.bytes) • A.toPoint
                        + (U8x32_as_Nat b.bytes) • _root_.Edwards.basepoint ⦄ := by
   sorry
 ```
-
 -/
 
 -- No Lean specification possible until extraction is unblocked.

--- a/functions.json
+++ b/functions.json
@@ -198,7 +198,7 @@
    "theorem add_spec\n    (self other : edwards.EdwardsPoint)\n    (h_self_valid : self.IsValid)\n    (h_other_valid : other.IsValid) :\n    add self other ⦃ (result : edwards.EdwardsPoint) =>\n      result.IsValid ∧\n      result.toPoint = self.toPoint + other.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/Add.lean",
    "spec_docstring":
-   "/-- **Spec and proof** concerning:\n`Shared0EdwardsPoint.Insts.CoreOpsArithAddSharedAEdwardsPointEdwardsPoint.add`:\n• The function always succeeds (no panic) for valid inputs\n• The result is a valid Edwards point\n• The result represents the sum of the inputs (in the context of elliptic curve addition)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::add`**\n• The function always succeeds (no panic) for valid inputs\n• The result is a valid Edwards point\n• The result represents the sum of the inputs (in the context of elliptic curve addition)\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{core::ops::arith::Add<&'a (curve25519_dalek::edwards::EdwardsPoint), curve25519_dalek::edwards::EdwardsPoint> for &1 (curve25519_dalek::edwards::EdwardsPoint)}::add",
@@ -284,10 +284,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem mul_spec (e : edwards.EdwardsPoint) (s : scalar.Scalar)\n    (h_s_canonical : U8x32_as_Nat s.bytes < 2 ^ 255)\n    (h_e_valid : e.IsValid) :\n    mul e s ⦃ result =>\n    result.IsValid ∧\n    result.toPoint = (U8x32_as_Nat s.bytes) • e.toPoint ⦄ := by ...",
+   "theorem mul_spec\n    (self : edwards.EdwardsPoint) (scalar : scalar.Scalar)\n    (h_scalar_canonical : U8x32_as_Nat scalar.bytes < 2 ^ 255)\n    (h_self_valid : self.IsValid) :\n    mul self scalar ⦃ (result : edwards.EdwardsPoint) =>\n      result.IsValid ∧\n      result.toPoint = (U8x32_as_Nat scalar.bytes) • self.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/Mul.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning\n`Shared0EdwardsPoint.Insts.CoreOpsArithMulSharedAScalarEdwardsPoint.mul`**:\n• The function always succeeds (no panic) for valid input EdwardsPoints e\n  and canonical Scalars s\n• The result is a valid EdwardsPoint\n• The result is mathematically correct, i.e.,\n  result.toPoint = e.toPoint + .. + e.toPoint (s-times)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul`**\n(trait impl `Mul<&Scalar> for &EdwardsPoint`).\n• The function always succeeds (no panic) for a valid input EdwardsPoint `self` and a\n  canonical Scalar `scalar`\n• The result is a valid EdwardsPoint\n• `result.toPoint` equals `(U8x32_as_Nat scalar.bytes) • self.toPoint`, i.e., scalar\n  multiplication of `self.toPoint` by the natural number encoded by `scalar.bytes`\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{core::ops::arith::Mul<&'a (curve25519_dalek::scalar::Scalar), curve25519_dalek::edwards::EdwardsPoint> for &1 (curve25519_dalek::edwards::EdwardsPoint)}::mul",
@@ -328,7 +328,7 @@
    "theorem neg_spec\n    (self : edwards.EdwardsPoint)\n    (h_self_valid : self.IsValid) :\n    neg self ⦃ (result : edwards.EdwardsPoint) =>\n      result.IsValid ∧\n      result.toPoint = -self.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/Neg.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `Shared0EdwardsPoint.Insts.CoreOpsArithNegEdwardsPoint.neg`**:\n• The function always succeeds (no panic) for valid inputs\n• The result is a valid Edwards point\n• The result represents the negation of the input (in the context of elliptic curve negation)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::neg`**\n• The function always succeeds (no panic) for valid inputs\n• The result is a valid Edwards point\n• The result represents the negation of the input (in the context of elliptic curve negation)\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{core::ops::arith::Neg<curve25519_dalek::edwards::EdwardsPoint> for &0 (curve25519_dalek::edwards::EdwardsPoint)}::neg",
@@ -415,7 +415,7 @@
    "theorem sub_spec\n    (self other : edwards.EdwardsPoint)\n    (h_self_valid : self.IsValid)\n    (h_other_valid : other.IsValid) :\n    sub self other ⦃ (result : edwards.EdwardsPoint) =>\n      result.IsValid ∧\n      result.toPoint = self.toPoint - other.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/Sub.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning\n`Shared0EdwardsPoint.Insts.CoreOpsArithSubSharedAEdwardsPointEdwardsPoint.sub`**:\n• The function always succeeds (no panic) for valid inputs\n• The result is a valid Edwards point\n• The result represents the difference of the inputs (in the context of elliptic curve subtraction)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::sub`**\n• The function always succeeds (no panic) for valid inputs\n• The result is a valid Edwards point\n• The result represents the difference of the inputs (in the context of elliptic curve subtraction)\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{core::ops::arith::Sub<&'a (curve25519_dalek::edwards::EdwardsPoint), curve25519_dalek::edwards::EdwardsPoint> for &1 (curve25519_dalek::edwards::EdwardsPoint)}::sub",
@@ -927,10 +927,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem mul_spec (s : scalar.Scalar) (e : edwards.EdwardsPoint)\n    (h_s_canonical : U8x32_as_Nat s.bytes < 2 ^ 255)\n    (h_e_valid : e.IsValid) :\n    mul s e ⦃ result =>\n    result.IsValid ∧\n    result.toPoint = (U8x32_as_Nat s.bytes) • e.toPoint ⦄ := by ...",
+   "theorem mul_spec\n    (self : scalar.Scalar) (point : edwards.EdwardsPoint)\n    (h_self_canonical : U8x32_as_Nat self.bytes < 2 ^ 255)\n    (h_point_valid : point.IsValid) :\n    mul self point ⦃ (result : edwards.EdwardsPoint) =>\n      result.IsValid ∧\n      result.toPoint = (U8x32_as_Nat self.bytes) • point.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/Mul.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning\n`Shared0Scalar.Insts.CoreOpsArithMulSharedAEdwardsPointEdwardsPoint.mul`**:\n• The function always succeeds (no panic) for canonical input Scalars s and\n  valid input EdwardsPoints e\n• The result is a valid EdwardsPoint\n• The result is mathematically correct, i.e.,\n  result.toPoint = e.toPoint + .. + e.toPoint (s-times)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::scalar::Scalar::mul`**\n(trait impl `Mul<&EdwardsPoint> for &Scalar`).\n• The function always succeeds (no panic) for a canonical input Scalar `self` and a\n  valid input EdwardsPoint `point`\n• The result is a valid EdwardsPoint\n• `result.toPoint` equals `(U8x32_as_Nat self.bytes) • point.toPoint`, i.e., scalar\n  multiplication of `point.toPoint` by the natural number encoded by `self.bytes`\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{core::ops::arith::Mul<&'a (curve25519_dalek::edwards::EdwardsPoint), curve25519_dalek::edwards::EdwardsPoint> for &1 (curve25519_dalek::scalar::Scalar)}::mul",
@@ -1316,10 +1316,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem mul_spec (e : edwards.EdwardsPoint) (s : scalar.Scalar)\n    (h_s_canonical : U8x32_as_Nat s.bytes < 2 ^ 255)\n    (h_e_valid : e.IsValid) :\n      mul e s ⦃ result =>\n      result.IsValid ∧\n      result.toPoint = ((U8x32_as_Nat s.bytes)) • e.toPoint ⦄ := by ...",
+   "theorem mul_spec\n    (self : edwards.EdwardsPoint) (rhs : scalar.Scalar)\n    (h_rhs_canonical : U8x32_as_Nat rhs.bytes < 2 ^ 255)\n    (h_self_valid : self.IsValid) :\n    mul self rhs ⦃ (result : edwards.EdwardsPoint) =>\n      result.IsValid ∧\n      result.toPoint = (U8x32_as_Nat rhs.bytes) • self.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/Mul.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning\n`SharedAEdwardsPoint.Insts.CoreOpsArithMulScalarEdwardsPoint.mul`**:\n• The function always succeeds (no panic) for valid input EdwardsPoints e\n  and canonical Scalars s\n• The result is a valid EdwardsPoint\n• The result is mathematically correct, i.e.,\n  result.toPoint = e.toPoint + .. + e.toPoint (s-times)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul`**\n(trait impl `Mul<Scalar> for &EdwardsPoint`).\n• The function always succeeds (no panic) for a valid input EdwardsPoint `self` and a\n  canonical Scalar `rhs`\n• The result is a valid EdwardsPoint\n• `result.toPoint` equals `(U8x32_as_Nat rhs.bytes) • self.toPoint`, i.e., scalar\n  multiplication of `self.toPoint` by the natural number encoded by `rhs.bytes`\n-/",
    "source": "curve25519-dalek/src/macros.rs",
    "rust_name":
    "curve25519_dalek::edwards::{core::ops::arith::Mul<curve25519_dalek::scalar::Scalar, curve25519_dalek::edwards::EdwardsPoint> for &'a (curve25519_dalek::edwards::EdwardsPoint)}::mul",
@@ -5418,10 +5418,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem eq_spec (self other : EdwardsPoint)\n    (h_self_valid : self.IsValid) (h_other_valid : other.IsValid) :\n    eq self other ⦃ result =>\n      result = true ↔ self.toPoint = other.toPoint ⦄ := by ...",
+   "theorem eq_spec (self other : EdwardsPoint)\n    (h_self_valid : self.IsValid) (h_other_valid : other.IsValid) :\n    eq self other ⦃ (result : Bool) =>\n      result = true ↔ self.toPoint = other.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/Eq.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.PartialEqEdwardsPoint.eq`**:\n• The function always succeeds (no panic) for valid inputs\n• The result is `true` if and only if the two points represent the same point on the curve\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::eq`**\n• The function always succeeds (no panic) for valid inputs\n• The result is `true` if and only if the two points represent the same point on the curve\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{core::cmp::PartialEq<curve25519_dalek::edwards::EdwardsPoint> for curve25519_dalek::edwards::EdwardsPoint}::eq",
@@ -5599,10 +5599,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem add_spec (self other : EdwardsPoint)\n    (h_self_valid : self.IsValid) (h_other_valid : other.IsValid) :\n    add self other ⦃ result =>\n      result.IsValid ∧\n      result.toPoint = self.toPoint + other.toPoint ⦄ := by ...",
+   "theorem add_spec\n    (self other : EdwardsPoint)\n    (h_self_valid : self.IsValid)\n    (h_other_valid : other.IsValid) :\n    add self other ⦃ (result : EdwardsPoint) =>\n      result.IsValid ∧\n      result.toPoint = self.toPoint + other.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/Add.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.AddEdwardsPointEdwardsPointEdwardsPoint.add`**:\n• The function always succeeds (no panic) for valid inputs\n• The result is a valid Edwards point\n• The result represents the sum of the inputs (in the context of elliptic curve addition)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::add`**\n• The function always succeeds (no panic) for valid inputs\n• The result is a valid Edwards point\n• The result represents the sum of the inputs (in the context of elliptic curve addition)\n-/",
    "source": "curve25519-dalek/src/macros.rs",
    "rust_name":
    "curve25519_dalek::edwards::{core::ops::arith::Add<curve25519_dalek::edwards::EdwardsPoint, curve25519_dalek::edwards::EdwardsPoint> for curve25519_dalek::edwards::EdwardsPoint}::add",
@@ -5961,10 +5961,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem sub_spec (self other : EdwardsPoint)\n    (h_self_valid : self.IsValid) (h_other_valid : other.IsValid) :\n    sub self other ⦃ result =>\n      result.IsValid ∧\n      result.toPoint = self.toPoint - other.toPoint ⦄ := by ...",
+   "theorem sub_spec\n    (self other : EdwardsPoint)\n    (h_self_valid : self.IsValid)\n    (h_other_valid : other.IsValid) :\n    sub self other ⦃ (result : EdwardsPoint) =>\n      result.IsValid ∧\n      result.toPoint = self.toPoint - other.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/Sub.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning\n`edwards.EdwardsPoint.Insts.CoreOpsArithSubEdwardsPointEdwardsPoint.sub`**:\n• The function always succeeds (no panic) for valid inputs\n• The result is a valid Edwards point\n• The result represents the difference of the inputs\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::sub`**\n• The function always succeeds (no panic) for valid inputs\n• The result is a valid Edwards point\n• The result represents the difference of the inputs (in the context of elliptic curve subtraction)\n-/",
    "source": "curve25519-dalek/src/macros.rs",
    "rust_name":
    "curve25519_dalek::edwards::{core::ops::arith::Sub<curve25519_dalek::edwards::EdwardsPoint, curve25519_dalek::edwards::EdwardsPoint> for curve25519_dalek::edwards::EdwardsPoint}::sub",
@@ -6043,10 +6043,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem identity_spec :\n    identity ⦃ (q : EdwardsPoint) =>\n      Field51_as_Nat q.X = 0 ∧ Field51_as_Nat q.Y = 1 ∧\n      Field51_as_Nat q.Z = 1 ∧ Field51_as_Nat q.T = 0 ∧\n      q.IsValid ∧ q.toPoint = 0 ⦄ := by ...",
+   "theorem identity_spec :\n    identity ⦃ (result : EdwardsPoint) =>\n      Field51_as_Nat result.X = 0 ∧\n      Field51_as_Nat result.Y = 1 ∧\n      Field51_as_Nat result.Z = 1 ∧\n      Field51_as_Nat result.T = 0 ∧\n      result.IsValid ∧\n      result.toPoint = 0 ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/Identity.lean",
    "spec_docstring":
-   "/-- **Spec and proof** concerning:\n `edwards.EdwardsPoint.Insts.Curve25519_dalekTraitsIdentity.identity`\n- No panic (always returns successfully)\n- The resulting EdwardsPoint is the identity element of the Ed25519 group\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::identity`**\n• The function always succeeds (no panic)\n• The resulting EdwardsPoint has coordinates (X = 0, Y = 1, Z = 1, T = 0)\n• The resulting EdwardsPoint is valid\n• The resulting EdwardsPoint represents the identity element of the Ed25519 group\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::traits::Identity for curve25519_dalek::edwards::EdwardsPoint}::identity",
@@ -6130,11 +6130,11 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem conditional_select_spec\n    (a b : EdwardsPoint)\n    (choice : subtle.Choice) :\n    conditional_select a b choice ⦃ (result : EdwardsPoint) =>\n      result = if choice.val = 1#u8 then b else a ⦄ := by ...",
+   "theorem conditional_select_spec (a b : EdwardsPoint) (choice : subtle.Choice) :\n    conditional_select a b choice ⦃ (result : EdwardsPoint) =>\n      result = if choice.val = 1#u8 then b else a ⦄ := by ...",
    "spec_file":
    "Curve25519Dalek/Specs/Edwards/EdwardsPoint/ConditionalSelect.lean",
    "spec_docstring":
-   "/--\n**Spec and proof concerning `edwards.EdwardsPoint.Insts.SubtleConditionallySelectable.conditional_select`**:\n- No panic (always returns successfully)\n- Returns `b` when `choice = 1` and `a` when `choice = 0`\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::conditional_select`**\n• No panic (always returns successfully)\n• Returns `b` when `choice = 1` and `a` when `choice = 0`\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{subtle::ConditionallySelectable for curve25519_dalek::edwards::EdwardsPoint}::conditional_select",
@@ -6173,10 +6173,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem ct_eq_spec (e1 e2 : EdwardsPoint)\n  -- Bounds are needed for the internal field multiplications\n  (h_e1_X : ∀ i, i < 5 → e1.X.val[i]!.val ≤ 2 ^ 53)\n  (h_e1_Y : ∀ i, i < 5 → e1.Y.val[i]!.val ≤ 2 ^ 53)\n  (h_e1_Z : ∀ i, i < 5 → e1.Z.val[i]!.val ≤ 2 ^ 53)\n  (h_e2_X : ∀ i, i < 5 → e2.X.val[i]!.val ≤ 2 ^ 53)\n  (h_e2_Y : ∀ i, i < 5 → e2.Y.val[i]!.val ≤ 2 ^ 53)\n  (h_e2_Z : ∀ i, i < 5 → e2.Z.val[i]!.val ≤ 2 ^ 53) :\n  ct_eq e1 e2 ⦃ c =>\n  (c = Choice.one ↔\n    (Field51_as_Nat e1.X * Field51_as_Nat e2.Z)\n      ≡ (Field51_as_Nat e2.X * Field51_as_Nat e1.Z) [MOD p] ∧\n    (Field51_as_Nat e1.Y * Field51_as_Nat e2.Z)\n      ≡ (Field51_as_Nat e2.Y * Field51_as_Nat e1.Z) [MOD p]) ∧\n  (e1.IsValid → e2.IsValid → (c = Choice.one ↔ e1.toPoint = e2.toPoint)) ⦄ := by ...",
+   "theorem ct_eq_spec (self other : EdwardsPoint)\n    (h_self_X : ∀ i, i < 5 → self.X.val[i]!.val ≤ 2 ^ 53)\n    (h_self_Y : ∀ i, i < 5 → self.Y.val[i]!.val ≤ 2 ^ 53)\n    (h_self_Z : ∀ i, i < 5 → self.Z.val[i]!.val ≤ 2 ^ 53)\n    (h_other_X : ∀ i, i < 5 → other.X.val[i]!.val ≤ 2 ^ 53)\n    (h_other_Y : ∀ i, i < 5 → other.Y.val[i]!.val ≤ 2 ^ 53)\n    (h_other_Z : ∀ i, i < 5 → other.Z.val[i]!.val ≤ 2 ^ 53) :\n    ct_eq self other ⦃ (c : subtle.Choice) =>\n      (c = Choice.one ↔\n        (Field51_as_Nat self.X * Field51_as_Nat other.Z)\n          ≡ (Field51_as_Nat other.X * Field51_as_Nat self.Z) [MOD p] ∧\n        (Field51_as_Nat self.Y * Field51_as_Nat other.Z)\n          ≡ (Field51_as_Nat other.Y * Field51_as_Nat self.Z) [MOD p]) ∧\n      (self.IsValid → other.IsValid → (c = Choice.one ↔ self.toPoint = other.toPoint)) ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/CtEq.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.ConstantTimeEqEdwardsPoint.ct_eq`**:\n- No panic (always returns successfully)\n- The result is `Choice.one` (true) iff the two points are equal (mod p) in\n  affine coordinates\n- When both points are valid, this is equivalent to `toPoint` equality\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::ct_eq`**\n• No panic (always returns successfully)\n• The result is `Choice.one` iff the cross-multiplied projective coordinates\n  agree mod p: `X·Z' ≡ X'·Z` and `Y·Z' ≡ Y'·Z` (mod p)\n• When both points are valid, this is equivalent to `toPoint` equality\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{subtle::ConstantTimeEq for curve25519_dalek::edwards::EdwardsPoint}::ct_eq",
@@ -6196,10 +6196,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem as_affine_niels_spec\n  (self : EdwardsPoint)\n  (hself : self.IsValid) :\n  as_affine_niels self ⦃ an =>\n  let X := Field51_as_Nat self.X\n  let Y := Field51_as_Nat self.Y\n  let Z := Field51_as_Nat self.Z\n  let ypx := Field51_as_Nat an.y_plus_x\n  let ymx := Field51_as_Nat an.y_minus_x\n  let xy2d_val := Field51_as_Nat an.xy2d\n  (ypx * Z) % p = (Y + X) % p ∧\n  (ymx * Z + X) % p = Y % p ∧\n  (xy2d_val * Z * Z) % p = (X * Y * (2 * d)) % p ∧\n  (∀ i < 5, an.y_plus_x[i]!.val < 2 ^ 54) ∧\n  (∀ i < 5, an.y_minus_x[i]!.val < 2 ^ 52) ∧\n  (∀ i < 5, an.xy2d[i]!.val < 2 ^ 52) ⦄\n := by ...",
+   "theorem as_affine_niels_spec\n    (self : EdwardsPoint)\n    (hself : self.IsValid) :\n    as_affine_niels self ⦃ (an : backend.serial.curve_models.AffineNielsPoint) =>\n      let X := Field51_as_Nat self.X\n      let Y := Field51_as_Nat self.Y\n      let Z := Field51_as_Nat self.Z\n      let ypx := Field51_as_Nat an.y_plus_x\n      let ymx := Field51_as_Nat an.y_minus_x\n      let xy2d_val := Field51_as_Nat an.xy2d\n      (ypx * Z) % p = (Y + X) % p ∧\n      (ymx * Z + X) % p = Y % p ∧\n      (xy2d_val * Z * Z) % p = (X * Y * (2 * d)) % p ∧\n      (∀ i < 5, an.y_plus_x[i]!.val < 2 ^ 54) ∧\n      (∀ i < 5, an.y_minus_x[i]!.val < 2 ^ 52) ∧\n      (∀ i < 5, an.xy2d[i]!.val < 2 ^ 52) ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/AsAffineNiels.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.EdwardsPoint.as_affine_niels`**:\n- No panic (always returns successfully)\n- Given input:\n  • an EdwardsPoint `self` satisfying `self.IsValid`\n    (coordinates X, Y, Z, T with limbs < 2^53, Z ≠ 0 in the field,\n    extended coordinate relation XY = TZ, and the curve equation),\nthe output AffineNielsPoint (y_plus_x, y_minus_x, xy2d) computed by\n`as_affine_niels self` satisfies modulo p:\n- y_plus_x · Z ≡ Y + X (mod p)\n- y_minus_x · Z + X ≡ Y (mod p)\n- xy2d · Z² ≡ X · Y · (2 · d) (mod p)\nwhere p = 2^255 - 19.\n\nThese are the standard affine Niels conversion formulas obtained by dehomogenizing\nthe extended coordinates and computing y ± x and 2dxy.\n\nOutput bounds (from field element arithmetic):\n- y_plus_x: all limbs < 2^54\n- y_minus_x: all limbs < 2^52\n- xy2d: all limbs < 2^52\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::as_affine_niels`**\n• The function always succeeds (no panic) for valid input EdwardsPoints\n• `y_plus_x · Z ≡ Y + X` (mod p)\n• `y_minus_x · Z + X ≡ Y` (mod p)\n• `xy2d · Z² ≡ X · Y · (2 · d)` (mod p)\n• `y_plus_x`: all limbs < 2^54\n• `y_minus_x`: all limbs < 2^52\n• `xy2d`: all limbs < 2^52\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::as_affine_niels",
@@ -6221,10 +6221,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem as_projective_spec (e : EdwardsPoint) :\n    edwards.EdwardsPoint.as_projective e ⦃ q =>\n    q.X = e.X ∧ q.Y = e.Y ∧ q.Z = e.Z ⦄ := by ...",
+   "theorem as_projective_spec (self : EdwardsPoint) :\n    as_projective self ⦃ (result : backend.serial.curve_models.ProjectivePoint) =>\n      result.X = self.X ∧\n      result.Y = self.Y ∧\n      result.Z = self.Z ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/AsProjective.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.EdwardsPoint.as_projective`**:\n- No panic (always returns successfully)\n- The resulting ProjectivePoint coordinates match the EdwardsPoint coordinates (X, Y, Z)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::as_projective`**\n• The function always succeeds (no panic)\n• The resulting `ProjectivePoint` has the same `X`, `Y`, `Z` coordinates as the input\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::as_projective",
@@ -6241,11 +6241,11 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem as_projective_niels_spec (e : EdwardsPoint)\n    (he : e.IsValid) :\n    as_projective_niels e ⦃ (pn : backend.serial.curve_models.ProjectiveNielsPoint) =>\n      let X := Field51_as_Nat e.X\n      let Y := Field51_as_Nat e.Y\n      let Z := Field51_as_Nat e.Z\n      let T := Field51_as_Nat e.T\n      let A := Field51_as_Nat pn.Y_plus_X\n      let B := Field51_as_Nat pn.Y_minus_X\n      let Z' := Field51_as_Nat pn.Z\n      let C := Field51_as_Nat pn.T2d\n      A % p = (Y + X) % p ∧\n      (B + X) % p = Y % p ∧\n      Z' % p = Z % p ∧\n      C % p = (T * (2 * d)) % p ∧\n      (∀ i < 5, (pn.Y_plus_X[i]!).val < 2 ^ 54 ∧\n      ∀ i < 5, (pn.Y_minus_X[i]!).val < 2 ^ 52 ∧\n      ∀ i < 5, (pn.Z[i]!).val < 2 ^ 53 ∧\n      ∀ i < 5, (pn.T2d[i]!).val < 2 ^ 52) ∧\n      pn.IsValid ∧\n      e.toPoint = pn.toPoint\n       ⦄ := by ...",
+   "theorem as_projective_niels_spec\n    (self : EdwardsPoint)\n    (hself : self.IsValid) :\n    as_projective_niels self ⦃ (pn : backend.serial.curve_models.ProjectiveNielsPoint) =>\n      let X := Field51_as_Nat self.X\n      let Y := Field51_as_Nat self.Y\n      let Z := Field51_as_Nat self.Z\n      let T := Field51_as_Nat self.T\n      let A := Field51_as_Nat pn.Y_plus_X\n      let B := Field51_as_Nat pn.Y_minus_X\n      let Z' := Field51_as_Nat pn.Z\n      let C := Field51_as_Nat pn.T2d\n      A % p = (Y + X) % p ∧\n      (B + X) % p = Y % p ∧\n      Z' % p = Z % p ∧\n      C % p = (T * (2 * d)) % p ∧\n      (∀ i < 5, (pn.Y_plus_X[i]!).val < 2 ^ 54 ∧\n      ∀ i < 5, (pn.Y_minus_X[i]!).val < 2 ^ 52 ∧\n      ∀ i < 5, (pn.Z[i]!).val < 2 ^ 53 ∧\n      ∀ i < 5, (pn.T2d[i]!).val < 2 ^ 52) ∧\n      pn.IsValid ∧\n      self.toPoint = pn.toPoint ⦄ := by ...",
    "spec_file":
    "Curve25519Dalek/Specs/Edwards/EdwardsPoint/AsProjectiveNiels.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.EdwardsPoint.as_projective_niels`**:\n- No panic (always returns successfully)\n- For the input Edwards point (X, Y, Z, T), the resulting ProjectiveNielsPoint has coordinates:\n  - A ≡ Y + X (mod p)\n  - B ≡ Y - X (mod p)\n  - Z' = Z\n  - C ≡ T * 2 * d (mod p)\nwhere p = 2^255 - 19\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::as_projective_niels`**\n• The function always succeeds (no panic) for valid input EdwardsPoints\n• The resulting `Y_plus_X` limb representation `A` satisfies `A ≡ Y + X (mod p)`\n• The resulting `Y_minus_X` limb representation `B` satisfies `B + X ≡ Y (mod p)`\n• The resulting `Z` limb representation `Z'` satisfies `Z' ≡ Z (mod p)`\n• The resulting `T2d` limb representation `C` satisfies `C ≡ T · (2 · d) (mod p)`\n• Limb bounds: `Y_plus_X` < 2^54, `Y_minus_X` < 2^52, `Z` < 2^53, `T2d` < 2^52\n• The result is a valid `ProjectiveNielsPoint`\n• The result represents the same elliptic curve point as the input\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::as_projective_niels",
@@ -6266,10 +6266,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem compress_spec (self : EdwardsPoint) (hself : self.IsValid) :\n    compress self ⦃ result =>\n      U8x32_as_Nat result = compress_edwards_pure self.toPoint ⦄ := by ...",
+   "theorem compress_spec (self : EdwardsPoint) (hself : self.IsValid) :\n    compress self ⦃ (result : CompressedEdwardsY) =>\n      U8x32_as_Nat result = compress_edwards_pure self.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/Compress.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.EdwardsPoint.compress`**:\n- Requires `self.IsValid` (limbs < 2^53, Z ≠ 0, extended relation, curve equation).\n- Ensures the compressed bytes equal the pure mathematical compression of the\n  corresponding abstract point:\n  `U8x32_as_Nat result = compress_edwards_pure self.toPoint`.\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::compress`**\n• The function always succeeds (no panic) when `self.IsValid`\n• The byte encoding of the result equals the pure mathematical compression of the\n  corresponding abstract point: `U8x32_as_Nat result = compress_edwards_pure self.toPoint`\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::compress",
@@ -6288,10 +6288,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem double_spec (e : EdwardsPoint) (he_valid : e.IsValid) :\n    double e ⦃ result =>\n    result.IsValid ∧ result.toPoint = e.toPoint + e.toPoint ⦄ := by ...",
+   "theorem double_spec (self : EdwardsPoint) (hself : self.IsValid) :\n    double self ⦃ (result : EdwardsPoint) =>\n      result.IsValid ∧\n      result.toPoint = self.toPoint + self.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/Double.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning\n`edwards.EdwardsPoint.double`**:\n- Returns the doubled point 2P (= P + P in elliptic\n  curve addition) where P is the input EdwardsPoint -/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::double`**\n• The function always succeeds (no panic) for valid input EdwardsPoints\n• The result is a valid Edwards point\n• The result represents the doubled input point 2P (= P + P) under elliptic curve addition\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::double",
@@ -6311,10 +6311,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem is_small_order_spec (self : EdwardsPoint) (hself : self.IsValid) :\n    is_small_order self ⦃ result =>\n    (result ↔ h • self.toPoint = 0) ⦄ := by ...",
+   "theorem is_small_order_spec (self : EdwardsPoint) (hself : self.IsValid) :\n    is_small_order self ⦃ (result : Bool) =>\n      (result ↔ h • self.toPoint = 0) ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/IsSmallOrder.lean",
    "spec_docstring":
-   "/-- **Spec for `edwards.EdwardsPoint.is_small_order`**:\n- Returns `true` if and only if the point has small order (is in the torsion subgroup E[8])\n- This is determined by checking if multiplying by the cofactor yields the identity element\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::is_small_order`**\n• The function always succeeds (no panic)\n• Returns `true` iff multiplying `self` by the cofactor yields the identity, i.e. `self ∈ E[8]`\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::is_small_order",
@@ -6335,10 +6335,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem is_torsion_free_spec (self : EdwardsPoint) (hself : self.IsValid) :\n    is_torsion_free self ⦃ result =>\n    (result ↔ L • self.toPoint = 0) ⦄ := by ...",
+   "theorem is_torsion_free_spec\n    (self : EdwardsPoint) (hself : self.IsValid) :\n    is_torsion_free self ⦃ (result : Bool) =>\n      (result ↔ L • self.toPoint = 0) ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/IsTorsionFree.lean",
    "spec_docstring":
-   "/-- **Spec for `edwards.EdwardsPoint.is_torsion_free`**:\n- Returns `true` if and only if the point is torsion-free (is in the prime-order subgroup)\n- This is determined by checking if multiplying by the basepoint order L yields the identity element\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::is_torsion_free`**\n• The function always succeeds (no panic)\n• Returns `true` if and only if the point is torsion-free, i.e. multiplying by the basepoint\n  order L yields the identity element of the Edwards curve\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::is_torsion_free",
@@ -6360,10 +6360,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem mul_base_spec (scalar : scalar.Scalar)\n    (h_s_canonical : U8x32_as_Nat scalar.bytes < 2 ^ 255) :\n    mul_base scalar ⦃ res =>\n    EdwardsPoint.IsValid res ∧\n    res.toPoint = (U8x32_as_Nat scalar.bytes) • _root_.Edwards.basepoint ⦄ := by ...",
+   "theorem mul_base_spec (scalar : scalar.Scalar)\n    (h_s_canonical : U8x32_as_Nat scalar.bytes < 2 ^ 255) :\n    mul_base scalar ⦃ (res : EdwardsPoint) =>\n      EdwardsPoint.IsValid res ∧\n      res.toPoint = (U8x32_as_Nat scalar.bytes) • _root_.Edwards.basepoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulBase.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.EdwardsPoint.mul_base`**:\n- No panic (always returns successfully)\n- Delegates to scalar multiplication with the Edwards basepoint constant\n- The returned EdwardsPoint equals the output of that scalar multiplication\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_base`**\n• Given a canonically-encoded scalar (`U8x32_as_Nat scalar.bytes < 2 ^ 255`),\n  the function always succeeds (no panic).\n• The returned `EdwardsPoint` is a valid Edwards point.\n• The returned `EdwardsPoint` represents `[s]B`, the scalar multiplication of\n  the input `scalar` with the Edwards basepoint.\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::mul_base",
@@ -6382,11 +6382,11 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem mul_base_clamped_spec (bytes : Array U8 32#usize) :\n    mul_base_clamped bytes ⦃ (result : EdwardsPoint) =>\n      EdwardsPoint.IsValid result ∧\n      (∃ clamped_scalar,\n      h ∣ U8x32_as_Nat clamped_scalar ∧\n      U8x32_as_Nat clamped_scalar < 2 ^ 255 ∧\n      2 ^ 254 ≤ U8x32_as_Nat clamped_scalar ∧\n      result.toPoint = ((U8x32_as_Nat clamped_scalar) • _root_.Edwards.basepoint)) ⦄ := by ...",
+   "theorem mul_base_clamped_spec (bytes : Array U8 32#usize) :\n    mul_base_clamped bytes ⦃ (result : EdwardsPoint) =>\n      EdwardsPoint.IsValid result ∧\n      (∃ clamped_scalar,\n        h ∣ U8x32_as_Nat clamped_scalar ∧\n        U8x32_as_Nat clamped_scalar < 2 ^ 255 ∧\n        2 ^ 254 ≤ U8x32_as_Nat clamped_scalar ∧\n        result.toPoint = ((U8x32_as_Nat clamped_scalar) • _root_.Edwards.basepoint)) ⦄ := by ...",
    "spec_file":
    "Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulBaseClamped.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.EdwardsPoint.mul_base_clamped`**:\n- No panic (always returns successfully)\n- Clamps input bytes with `scalar.clamp_integer`\n- Delegates to `edwards.EdwardsPoint.mul_base` with the clamped scalar\n- The returned EdwardsPoint matches the basepoint multiplication result\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_base_clamped`**\n• The function always succeeds (no panic)\n• The returned `EdwardsPoint` is a valid Edwards point\n• The returned point equals the scalar multiplication of the Edwards basepoint\n  by a clamped scalar derived from the input bytes, divisible by the cofactor\n  `h` and lying in `[2^254, 2^255)`\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::mul_base_clamped",
@@ -6405,10 +6405,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem mul_by_cofactor_spec (self : EdwardsPoint) (hself : self.IsValid) :\n    mul_by_cofactor self ⦃ result =>\n      result.IsValid ∧\n      result.toPoint = h • self.toPoint ⦄ := by ...",
+   "theorem mul_by_cofactor_spec (self : EdwardsPoint) (hself : self.IsValid) :\n    mul_by_cofactor self ⦃ (result : EdwardsPoint) =>\n      result.IsValid ∧\n      result.toPoint = h • self.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulByCofactor.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.EdwardsPoint.mul_by_cofactor`**:\n- No panic (always returns successfully)\n- Returns an EdwardsPoint that represents 8e = (2 ^ 3) * e\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_by_cofactor`**\n• The function always succeeds (no panic) for valid input `EdwardsPoint`s\n• Returns a valid `EdwardsPoint`\n• `result.toPoint` equals `8 • self.toPoint` (i.e. `[8]e`, multiplication by the cofactor)\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::mul_by_cofactor",
@@ -6425,10 +6425,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem mul_by_pow_2_spec (self : EdwardsPoint) (k : U32)\n    (hself : self.IsValid) (hk : k.val > 0) :\n    mul_by_pow_2 self k ⦃ result =>\n      result.IsValid ∧\n      result.toPoint = (2 ^ k.val) • self.toPoint ⦄ := by ...",
+   "theorem mul_by_pow_2_spec (self : EdwardsPoint) (k : U32)\n    (hself : self.IsValid) (hk : k.val > 0) :\n    mul_by_pow_2 self k ⦃ (result : EdwardsPoint) =>\n      result.IsValid ∧\n      result.toPoint = (2 ^ k.val) • self.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulByPow2.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.EdwardsPoint.mul_by_pow_2`**:\n- For k = 1, returns the doubled point 2e for the input point e\n- For k > 1, returns a point equal to double(mul_by_pow_2(e, k-1))\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_by_pow_2`**\n• Does not panic for a valid input point `self` and `k > 0`\n• The result is a valid `EdwardsPoint`\n• The result equals `2 ^ k` scalar-multiplied with the input point `self`\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::mul_by_pow_2",
@@ -6471,10 +6471,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem mul_clamped_spec (self : EdwardsPoint) (bytes : Array U8 32#usize)\n    (h_self_valid : self.IsValid) :\n    mul_clamped self bytes ⦃ (result : EdwardsPoint) =>\n      EdwardsPoint.IsValid result ∧\n      (∃ clamped_scalar,\n      h ∣ U8x32_as_Nat clamped_scalar ∧\n      U8x32_as_Nat clamped_scalar < 2 ^ 255 ∧\n      2 ^ 254 ≤ U8x32_as_Nat clamped_scalar ∧\n      result.toPoint = (((U8x32_as_Nat clamped_scalar)) • self.toPoint)) ⦄ := by ...",
+   "theorem mul_clamped_spec (self : EdwardsPoint) (bytes : Array U8 32#usize)\n    (h_self_valid : self.IsValid) :\n    mul_clamped self bytes ⦃ (result : EdwardsPoint) =>\n      result.IsValid ∧\n      (∃ clamped_scalar,\n        h ∣ U8x32_as_Nat clamped_scalar ∧\n        U8x32_as_Nat clamped_scalar < 2 ^ 255 ∧\n        2 ^ 254 ≤ U8x32_as_Nat clamped_scalar ∧\n        result.toPoint = (U8x32_as_Nat clamped_scalar) • self.toPoint) ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/MulClamped.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.EdwardsPoint.mul_clamped`**:\n- No panic (always returns successfully)\n- Clamps input bytes with `scalar.clamp_integer`\n- Delegates to `Scalar * EdwardsPoint` multiplication with the clamped scalar\n- The returned EdwardsPoint matches the scalar multiplication result\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::mul_clamped`**\n• The function always succeeds (no panic) for a valid input EdwardsPoint `self`\n• The result is a valid EdwardsPoint\n• There exists a clamped 32-byte scalar `c` (the bitwise-clamped form of `bytes`)\n  such that `c` is divisible by the cofactor `h = 8`\n• `c < 2^255`\n• `2^254 ≤ c`\n• `result.toPoint = c • self.toPoint`, i.e., scalar multiplication of `self.toPoint`\n  by the natural number `c`\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::mul_clamped",
@@ -6493,10 +6493,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem to_affine_spec (e : EdwardsPoint) (hself : e.IsValid) :\n    to_affine e ⦃ ap =>\n      ap.IsValid ∧\n      ap.toPoint = e.toPoint ⦄ := by ...",
+   "theorem to_affine_spec (self : EdwardsPoint) (hself : self.IsValid) :\n    to_affine self ⦃ (ap : affine.AffinePoint) =>\n      ap.IsValid ∧\n      ap.toPoint = self.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/ToAffine.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `edwards.EdwardsPoint.to_affine`** (math-bridged):\n- Requires `self.IsValid` (limbs `< 2^53`, `Z ≠ 0`, extended relation, curve equation).\n- Ensures `result.IsValid` (the affine point satisfies the curve equation).\n- Math bridge: `result.toPoint = self.toPoint` in `Point Ed25519`.\n\nWraps the operational `to_affine_spec'` and lifts its Nat-modular postconditions to\nthe abstract `Point Ed25519` group.\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::to_affine`**\n• The function always succeeds (no panic) for a valid `EdwardsPoint`\n• The result is a valid affine point\n• The result represents the same abstract point: `result.toPoint = self.toPoint`\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::to_affine",
@@ -6515,9 +6515,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem to_montgomery_spec (e : EdwardsPoint)\n    (hvalid : e.IsValid)\n    (h_Y_bounds : ∀ i < 5, e.Y[i]!.val < 2 ^ 53) (h_Z_bounds : ∀ i < 5, e.Z[i]!.val < 2 ^ 53) :\n    to_montgomery e ⦃ mp =>\n      let Y := Field51_as_Nat e.Y\n      let Z := Field51_as_Nat e.Z\n      let u := U8x32_as_Nat mp\n      if Z % p = Y % p then\n        u % p = 0 ∧ (∀ n : ℕ, fromEdwards (n • e.toPoint) = 0)\n      else\n      ((u * Z) % p = (u * Y + (Z + Y)) % p) ∧\n      ( abs_montgomery (fromEdwards (e.toPoint)) = (MontgomeryPoint.mkPoint mp)) ⦄ := by ...",
+   "theorem to_montgomery_spec (self : EdwardsPoint)\n    (hvalid : self.IsValid)\n    (h_Y_bounds : ∀ i < 5, self.Y[i]!.val < 2 ^ 53)\n    (h_Z_bounds : ∀ i < 5, self.Z[i]!.val < 2 ^ 53) :\n    to_montgomery self ⦃ (mp : montgomery.MontgomeryPoint) =>\n      let Y := Field51_as_Nat self.Y\n      let Z := Field51_as_Nat self.Z\n      let u := U8x32_as_Nat mp\n      if Z % p = Y % p then\n        u % p = 0 ∧ (∀ n : ℕ, fromEdwards (n • self.toPoint) = 0)\n      else\n        ((u * Z) % p = (u * Y + (Z + Y)) % p) ∧\n        abs_montgomery (fromEdwards self.toPoint) = MontgomeryPoint.mkPoint mp ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/ToMontgomery.lean",
-   "spec_docstring": null,
+   "spec_docstring":
+   "/-- **Spec theorem for `curve25519_dalek::edwards::EdwardsPoint::to_montgomery`**\n• The function always succeeds (no panic) for any valid input Edwards point\n• In the degenerate case `Z ≡ Y (mod p)`, the output u-coordinate satisfies\n  `u ≡ 0 (mod p)`\n• In the same degenerate case, `fromEdwards (n • self.toPoint) = 0` for every natural number `n`\n• In the generic case `Z ≢ Y (mod p)`, the output u-coordinate satisfies\n  `u * Z ≡ u * Y + (Z + Y) (mod p)`, equivalently `u ≡ (Z + Y) / (Z - Y) (mod p)`\n• In the generic case, `MontgomeryPoint.mkPoint mp` equals\n  `abs_montgomery (fromEdwards self.toPoint)`\n-/",
    "source": "curve25519-dalek/src/edwards.rs",
    "rust_name":
    "curve25519_dalek::edwards::{curve25519_dalek::edwards::EdwardsPoint}::to_montgomery",
@@ -10059,10 +10060,10 @@
    "verified": true,
    "specified": true,
    "spec_statement":
-   "theorem mul_spec (s : scalar.Scalar) (e : edwards.EdwardsPoint)\n    (h_s_canonical : U8x32_as_Nat s.bytes < 2 ^ 255)\n    (h_e_valid : e.IsValid) :\n    mul s e ⦃ result =>\n      result.IsValid ∧\n      result.toPoint = ((U8x32_as_Nat s.bytes)) • e.toPoint ⦄ := by ...",
+   "theorem mul_spec\n    (self : scalar.Scalar) (rhs : edwards.EdwardsPoint)\n    (h_self_canonical : U8x32_as_Nat self.bytes < 2 ^ 255)\n    (h_rhs_valid : rhs.IsValid) :\n    mul self rhs ⦃ (result : edwards.EdwardsPoint) =>\n      result.IsValid ∧\n      result.toPoint = (U8x32_as_Nat self.bytes) • rhs.toPoint ⦄ := by ...",
    "spec_file": "Curve25519Dalek/Specs/Edwards/EdwardsPoint/Mul.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning\n`scalar.Scalar.Insts.CoreOpsArithMulEdwardsPointEdwardsPoint.mul`**:\n• The function always succeeds (no panic) for canonical input Scalars s and\n  valid input EdwardsPoints e\n• The result is a valid EdwardsPoint\n• The result is mathematically correct, i.e.,\n  result.toPoint = e.toPoint + .. + e.toPoint (s-times)\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::scalar::Scalar::mul`**\n(trait impl `Mul<EdwardsPoint> for Scalar`).\n• The function always succeeds (no panic) for a canonical input Scalar `self` and a\n  valid input EdwardsPoint `rhs`\n• The result is a valid EdwardsPoint\n• `result.toPoint` equals `(U8x32_as_Nat self.bytes) • rhs.toPoint`, i.e., scalar\n  multiplication of `rhs.toPoint` by the natural number encoded by `self.bytes`\n-/",
    "source": "curve25519-dalek/src/macros.rs",
    "rust_name":
    "curve25519_dalek::edwards::{core::ops::arith::Mul<curve25519_dalek::edwards::EdwardsPoint, curve25519_dalek::edwards::EdwardsPoint> for curve25519_dalek::scalar::Scalar}::mul",


### PR DESCRIPTION
This PR systematically streamlines the style, formatting, and code of all 23 spec theorem files in:

- Specs/Edwards/EdwardsPoint

This PR fixes many small issues, establishing a consistent and clean style.

Frequently made improvements include:

- Adding explicit type annotations to Aeneas result binders: ⦃ result => → ⦃ (result : SomeType) =>
- Name shortenings via removal of redundant prefixes (Std.U8 → U8, scalar.Scalar → Scalar)
- Combining open statements (open A + open B → open A B)
- Merging mathematical information in "natural language description / natural language specs" into module and theorem docstrings
- General docstring improvements
- ...

Closes #776