### PR TITLE
style: streamline all files in Specs/Backend/Serial/CurveModels

### DIFF
--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Add.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Add.lean
@@ -7,10 +7,7 @@ import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.CurveModels.CompletedPoint.Add
 
-/-!
-# Spec theorem for `CompletedPoint::add`
-
-Specification and proof for `CompletedPoint::add`.
+/-! # Spec theorem for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::add`
 
 This function implements the mixed addition of an AffineNielsPoint to an
 Edwards point in extended coordinates, returning the result in completed
@@ -36,12 +33,11 @@ Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs"
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.curve_models
-
 namespace curve25519_dalek.Shared0EdwardsPoint.Insts
 namespace CoreOpsArithAddSharedAAffineNielsPointCompletedPoint
 
-
-/-- **Spec theorem for `CompletedPoint::add`**:
+/-- Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::add`
 • The function always succeeds (no panic)
 • Given inputs P = (X, Y, Z, T) and N = (Y+X, Y−X, 2dXY), the output C = (X', Y', Z', T')
   satisfies modulo p:

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Add.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Add.lean
@@ -36,8 +36,9 @@ open curve25519_dalek.backend.serial.curve_models
 namespace curve25519_dalek.Shared0EdwardsPoint.Insts
 namespace CoreOpsArithAddSharedAAffineNielsPointCompletedPoint
 
-/-- Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::add`
+/-- **Spec theorem**
+
+Sepcification for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::add`.
 • The function always succeeds (no panic)
 • Given inputs P = (X, Y, Z, T) and N = (Y+X, Y−X, 2dXY), the output C = (X', Y', Z', T')
   satisfies modulo p:

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/AssertReceiverIsTotalEq.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/AssertReceiverIsTotalEq.lean
@@ -5,12 +5,9 @@ Authors: Hoang Le Truong
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
-/-!
-# Spec theorem for `AffineNielsPoint::assert_receiver_is_total_eq`
 
-Specification and proof for
-`curve25519_dalek::backend::serial::curve_models::{core::cmp::Eq for
-curve25519_dalek::backend::serial::curve_models::AffineNielsPoint}::assert_receiver_is_total_eq`.
+/-! Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::assert_receiver_is_total_eq`
 
 This function is the totality assertion required by Rust's `Eq` trait. For
 `AffineNielsPoint`, it is a no-op and always succeeds.
@@ -19,13 +16,13 @@ Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs", lines 182:22-
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-
 namespace curve25519_dalek.backend.serial.curve_models.AffineNielsPoint.Insts.CoreCmpEq
 
-/-- **Spec theorem for `AffineNielsPoint.Insts.CoreCmpEq.assert_receiver_is_total_eq`**:
-- No panic (always returns successfully)
-- The result is `()`
-- This is the `Eq`-trait totality assertion for `AffineNielsPoint` -/
+/-- Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::assert_receiver_is_total_eq`
+• No panic (always returns successfully)
+• The result is `()`
+• This is the `Eq`-trait totality assertion for `AffineNielsPoint` -/
 @[step]
 theorem assert_receiver_is_total_eq_spec
     (self : backend.serial.curve_models.AffineNielsPoint) :

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/AssertReceiverIsTotalEq.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/AssertReceiverIsTotalEq.lean
@@ -6,8 +6,11 @@ Authors: Hoang Le Truong
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 
-/-! Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::assert_receiver_is_total_eq`
+/-!
+# Spec theorem
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::assert_receiver_is_total_eq`.
 
 This function is the totality assertion required by Rust's `Eq` trait. For
 `AffineNielsPoint`, it is a no-op and always succeeds.
@@ -18,8 +21,10 @@ Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs", lines 182:22-
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.backend.serial.curve_models.AffineNielsPoint.Insts.CoreCmpEq
 
-/-- Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::assert_receiver_is_total_eq`
+/-- **Spec theorem**
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::assert_receiver_is_total_eq`.
 • No panic (always returns successfully)
 • The result is `()`
 • This is the `Eq`-trait totality assertion for `AffineNielsPoint` -/

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/ConditionalAssign.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/ConditionalAssign.lean
@@ -6,10 +6,9 @@ Authors: Hoang Le Truong
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ConditionalAssign
-/-!
-# Spec theorem for `AffineNielsPoint::conditional_assign`
 
-Specification and proof for `AffineNielsPoint::conditional_assign`.
+/-! Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_assign`
 
 This function conditionally assigns the value of another AffineNielsPoint
 to self based on a Choice value. It is a constant-time operation used in
@@ -28,20 +27,20 @@ Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs, lines 322:4-32
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-
 namespace curve25519_dalek.backend.serial.curve_models.AffineNielsPoint.Insts
 namespace SubtleConditionallySelectable
 
-/-- **Spec theorem for `backend::serial::curve_models::AffineNielsPoint::conditional_assign`**
-- No panic (always returns successfully)
-- Given inputs:
+/-- **Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_assign`**
+• No panic (always returns successfully)
+• Given inputs:
   • an AffineNielsPoint `self` with coordinates (y_plus_x, y_minus_x, xy2d),
   • an AffineNielsPoint `other` with coordinates (y_plus_x', y_minus_x', xy2d'),
   • a Choice `choice`,
 the output AffineNielsPoint computed by `conditional_assign self other choice` satisfies:
-- Each coordinate is conditionally selected: if choice is 1, output = other;
+• Each coordinate is conditionally selected: if choice is 1, output = other;
   if choice is 0, output = self
-- The operation is performed in constant time for all field elements -/
+• The operation is performed in constant time for all field elements -/
 @[step]
 theorem conditional_assign_spec
     (self other : backend.serial.curve_models.AffineNielsPoint)

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/ConditionalAssign.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/ConditionalAssign.lean
@@ -7,8 +7,11 @@ import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ConditionalAssign
 
-/-! Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_assign`
+/-!
+# Spec theorem
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_assign`.
 
 This function conditionally assigns the value of another AffineNielsPoint
 to self based on a Choice value. It is a constant-time operation used in
@@ -30,8 +33,10 @@ open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.backend.serial.curve_models.AffineNielsPoint.Insts
 namespace SubtleConditionallySelectable
 
-/-- **Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_assign`**
+/-- **Spec theorem**
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_assign`.
 • No panic (always returns successfully)
 • Given inputs:
   • an AffineNielsPoint `self` with coordinates (y_plus_x, y_minus_x, xy2d),

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/ConditionalSelect.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/ConditionalSelect.lean
@@ -6,10 +6,9 @@ Authors: Hoang Le Truong
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ConditionalSelect
-/-!
-# Spec theorem for `AffineNielsPoint::conditional_select`
 
-Specification and proof for `AffineNielsPoint::conditional_select`.
+/-! Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_select`
 
 This function conditionally selects between two AffineNielsPoint values
 based on a Choice flag. It is implemented by applying
@@ -21,21 +20,16 @@ Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-
 namespace curve25519_dalek.backend.serial.curve_models.AffineNielsPoint.Insts
 namespace SubtleConditionallySelectable
 
 /-- **Spec theorem for
 `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_select`**
-- No panic (always returns successfully)
-- Given inputs:
-  • AffineNielsPoint `a` with coordinates (y_plus_x, y_minus_x, xy2d),
-  • AffineNielsPoint `b` with coordinates (y_plus_x', y_minus_x', xy2d'),
-  • a Choice `choice`,
-  the output AffineNielsPoint has coordinates selected component-wise:
+• The function always succeeds (no panic) for AffineNielsPoints `a` and `b` and a Choice `choice`
+• The result is an AffineNielsPoint whose coordinates are selected component-wise:
   - If choice = 1, each coordinate equals the corresponding one of `b`
   - If choice = 0, each coordinate equals the corresponding one of `a`
-  - The operation is constant-time (does not branch on choice) -/
+• The operation is constant-time (does not branch on choice) -/
 @[step]
 theorem conditional_select_spec
     (a b : backend.serial.curve_models.AffineNielsPoint)

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/ConditionalSelect.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/ConditionalSelect.lean
@@ -7,8 +7,11 @@ import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ConditionalSelect
 
-/-! Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_select`
+/-!
+# Spec theorem
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_select`.
 
 This function conditionally selects between two AffineNielsPoint values
 based on a Choice flag. It is implemented by applying
@@ -23,8 +26,10 @@ open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.backend.serial.curve_models.AffineNielsPoint.Insts
 namespace SubtleConditionallySelectable
 
-/-- **Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_select`**
+/-- **Spec theorem**
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_select`.
 • The function always succeeds (no panic) for AffineNielsPoints `a` and `b` and a Choice `choice`
 • The result is an AffineNielsPoint whose coordinates are selected component-wise:
   - If choice = 1, each coordinate equals the corresponding one of `b`

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Eq.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Eq.lean
@@ -6,13 +6,8 @@ Authors: Hoang Le Truong
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.CtEq
-/-!
-# Spec theorem for `AffineNielsPoint::eq`
 
-Specification and proof for
-`curve25519_dalek::backend::serial::curve_models::{core::cmp::PartialEq<
-curve25519_dalek::backend::serial::curve_models::AffineNielsPoint> for
-curve25519_dalek::backend::serial::curve_models::AffineNielsPoint}::eq`.
+/-! # Spec theorem for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::eq`
 
 This function compares two AffineNielsPoint values component-wise using
 `FieldElement51` equality, short-circuiting on the first mismatch.
@@ -21,7 +16,6 @@ Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-
 namespace curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts
 namespace CoreCmpPartialEqFieldElement51
 
@@ -46,9 +40,9 @@ namespace curve25519_dalek.backend.serial.curve_models.AffineNielsPoint.Insts
 namespace CoreCmpPartialEqAffineNielsPoint
 
 /-- **Spec theorem for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::eq`**
-- No panic (always returns successfully)
-- Returns true iff all three coordinate comparisons return true
-- Short-circuits to false as soon as a comparison fails -/
+• No panic (always returns successfully)
+• Returns true iff all three coordinate comparisons return true
+• Short-circuits to false as soon as a comparison fails -/
 @[step]
 theorem eq_spec
     (self other : backend.serial.curve_models.AffineNielsPoint) :

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Identity.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Identity.lean
@@ -8,10 +8,8 @@ import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ZERO
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ONE
-/-!
-# Spec theorem for `AffineNielsPoint::identity`
 
-Specification and proof for `AffineNielsPoint::identity`.
+/-! # Spec theorem for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::identity`
 
 This function returns the identity element of the Edwards curve in AffineNiels coordinates
 (y_plus_x, y_minus_x, xy2d). The identity element on the Edwards curve is the affine point
@@ -30,8 +28,8 @@ namespace Curve25519_dalekTraitsIdentity
 
 /-- **Spec theorem for
 `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::identity`**
-- No panic (always returns successfully)
-- The resulting AffineNielsPoint is the identity element with coordinates:
+• No panic (always returns successfully)
+• The resulting AffineNielsPoint is the identity element with coordinates:
   y_plus_x = 1, y_minus_x = 1, xy2d = 0 -/
 @[step]
 theorem identity_spec :

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Identity.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Identity.lean
@@ -26,8 +26,9 @@ open backend.serial.u64.field.FieldElement51
 namespace curve25519_dalek.backend.serial.curve_models.AffineNielsPoint.Insts
 namespace Curve25519_dalekTraitsIdentity
 
-/-- **Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::identity`**
+/-- **Spec theorem**
+
+Specification for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::identity`.
 • No panic (always returns successfully)
 • The resulting AffineNielsPoint is the identity element with coordinates:
   y_plus_x = 1, y_minus_x = 1, xy2d = 0 -/

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Neg.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Neg.lean
@@ -7,10 +7,8 @@ import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Neg
-/-!
-# Spec theorem for `AffineNielsPoint::neg`
 
-Specification and proof for `AffineNielsPoint::neg`.
+/-! # Spec theorem for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::neg`
 
 This function implements the negation of a point in affine Niels coordinates.
 Given an AffineNielsPoint N = (y+x, y−x, 2dxy), it computes -N by:
@@ -27,22 +25,15 @@ Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs"
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.curve_models
-
 namespace curve25519_dalek.Shared0AffineNielsPoint.Insts.CoreOpsArithNegAffineNielsPoint
 
 /-- **Spec theorem for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::neg`**
-- No panic (always returns successfully)
-- Given input:
-  • an AffineNielsPoint `self` with coordinates (y_plus_x, y_minus_x, xy2d),
-the output AffineNielsPoint computed by `neg self` has coordinates
-(y_plus_x', y_minus_x', xy2d') where:
-    - y_plus_x' = y_minus_x (the coordinates are swapped)
-    - y_minus_x' = y_plus_x (the coordinates are swapped)
-    - xy2d' ≡ -xy2d (mod p) (the xy2d coordinate is negated modulo p)
-
-where p = 2^255 - 19.
-
-This implements the negation of a point in affine Niels coordinates. -/
+• The function always succeeds (no panic) for an AffineNielsPoint `self` with coordinates
+(y_plus_x, y_minus_x, xy2d)
+• The output AffineNielsPoint computed by `neg self` has coordinates (y_plus_x', y_minus_x', xy2d')
+  • y_plus_x' = y_minus_x (the coordinates are swapped)
+  • y_minus_x' = y_plus_x (the coordinates are swapped)
+  • `xy2d' ≡ -xy2d (mod p)` (the xy2d coordinate is negated modulo p = 2^255 - 19) -/
 @[step]
 theorem neg_spec
     (self : backend.serial.curve_models.AffineNielsPoint)

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Sub.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Sub.lean
@@ -7,10 +7,7 @@ import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.CurveModels.CompletedPoint.Add
 
-/-!
-# Spec theorem for `CompletedPoint::sub`
-
-Specification and proof for `CompletedPoint::sub`.
+/-! # Spec theorem for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::sub`
 
 This function implements the mixed subtraction of an AffineNielsPoint from an
 Edwards point in extended coordinates, returning the result in completed
@@ -36,12 +33,10 @@ Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs"
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.curve_models
-
 namespace curve25519_dalek.Shared0EdwardsPoint.Insts
 namespace CoreOpsArithSubSharedAAffineNielsPointCompletedPoint
 
-
-/-- **Spec theorem for `CompletedPoint::sub`**:
+/-- **Spec theorem for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::sub`**
 • The function always succeeds (no panic)
 • Given inputs P = (X, Y, Z, T) and N = (Y+X, Y−X, 2dXY), the output C = (X', Y', Z', T')
   satisfies modulo p:

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/CompletedPoint/Add.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/CompletedPoint/Add.lean
@@ -11,10 +11,7 @@ import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Sub
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.AddAssign
 
-/-!
-# Spec theorem for `CompletedPoint::add`
-
-Specification and proof for `CompletedPoint::add`.
+/-! # Spec theorem for `curve25519_dalek::backend::serial::curve_models::CompletedPoint::add`
 
 This function implements the mixed addition of an Edwards point in extended
 coordinates with a point in projective Niels coordinates, returning the result
@@ -49,37 +46,19 @@ open CoreOpsArithAddAssignSharedAFieldElement51
 open curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithAddSharedAFieldElement51FieldElement51
 namespace curve25519_dalek.backend.serial.curve_models.CompletedPoint
 
-/-
-natural language description:
-
-• Takes an EdwardsPoint (X, Y, Z, T) in extended coordinates and a ProjectiveNielsPoint
-(Y+X, Y−X, Z, 2dXY) and returns a CompletedPoint (X', Y', Z', T') in completed coordinates
-(ℙ¹ × ℙ¹). Arithmetic is performed in the field 𝔽_p where p = 2^255 - 19.
-
-natural language specs:
-
-• The function always succeeds (no panic)
-• Given inputs P = (X, Y, Z, T) and N = (Y+X, Y−X, Z, 2dXY), the output C = (X', Y', Z', T')
-  satisfies modulo p:
-  - X' ≡ ( (Y+X)·N.Y_plus_X − (Y−X)·N.Y_minus_X ) (mod p)
-  - Y' ≡ ( (Y+X)·N.Y_plus_X + (Y−X)·N.Y_minus_X ) (mod p)
-  - Z' ≡ ( 2·Z·N.Z + T·N.T2d ) (mod p)
-  - T' ≡ ( 2·Z·N.Z − T·N.T2d ) (mod p)
--/
-/-- **Spec and proof concerning `backend.serial.curve_models.CompletedPoint.add`**:
-- No panic (always returns successfully)
-- Given inputs:
+/-- **Helper for `curve25519_dalek::backend::serial::curve_models::CompletedPoint::add`**
+• No panic (always returns successfully)
+• Given inputs:
   • an EdwardsPoint `self` with coordinates (X, Y, Z, T), and
   • a ProjectiveNielsPoint `other` with coordinates (Y_plus_X, Y_minus_X, Z, T2d),
 the output CompletedPoint (X', Y', Z', T') computed by `add self other` satisfies modulo p:
-- X' ≡ ( (Y+X)·Y_plus_X − (Y−X)·Y_minus_X ) (mod p)
-- Y' ≡ ( (Y+X)·Y_plus_X + (Y−X)·Y_minus_X ) (mod p)
-- Z' ≡ ( 2·Z·Z_other + T·T2d ) (mod p)
-- T' ≡ ( 2·Z·Z_other − T·T2d ) (mod p)
+• X' ≡ ( (Y+X)·Y_plus_X − (Y−X)·Y_minus_X ) (mod p)
+• Y' ≡ ( (Y+X)·Y_plus_X + (Y−X)·Y_minus_X ) (mod p)
+• Z' ≡ ( 2·Z·Z_other + T·T2d ) (mod p)
+• T' ≡ ( 2·Z·Z_other − T·T2d ) (mod p)
 where p = 2^255 - 19
 These are the standard mixed-addition formulas via projective Niels coordinates,
-returning the result in completed coordinates.
--/
+returning the result in completed coordinates. -/
 theorem add_assign_spec' (a b : Array U64 5#usize)
     (ha : ∀ i < 5, a[i]!.val < 2 ^ 54)
     (hb : ∀ i < 5, b[i]!.val < 2 ^ 52) :
@@ -273,10 +252,10 @@ Input bounds: EdwardsPoint coords < 2^53, ProjectiveNielsPoint coords < 2^53.
 Output: arithmetic relations modulo p with explicit output bounds.
 
 Output bounds (all < 2^54, so output satisfies CompletedPoint.IsValid):
-- X (from sub): < 2^52
-- Y (from add PP+MM): < 2^53
-- Z (from add ZZ2+TT2d): < 2^54 (ZZ2 < 2^53, TT2d < 2^52)
-- T (from sub): < 2^52
+• X (from sub): < 2^52
+• Y (from add PP+MM): < 2^53
+• Z (from add ZZ2+TT2d): < 2^54 (ZZ2 < 2^53, TT2d < 2^52)
+• T (from sub): < 2^52
 -/
 theorem add_spec_aux_54_52_53_52
     (self : edwards.EdwardsPoint)
@@ -699,11 +678,11 @@ private lemma add_spec_algebraic
     hX_factored hY_factored hZ_factored hT_factored h_denom_plus h_denom_minus
 
 
-/-- **Spec theorem for `curve25519_dalek.backend.serial.curve_models.CompletedPoint.add`**
-The theorem states that adding a valid EdwardsPoint with a valid ProjectiveNielsPoint:
-1. Always succeeds
-2. The output CompletedPoint is valid (bounds and algebraic properties)
-3. The output represents the sum of the input points
+/-- **Spec theorem for `curve25519_dalek::backend::serial::curve_models::CompletedPoint::add`**
+• Always succeeds (no panic) when both inputs are valid
+• The output CompletedPoint is valid (bounds and algebraic properties)
+• The output represents the sum of the input points: `c.toPoint = self.toPoint + other.toPoint`
+
 The mixed addition formulas implement elliptic curve point addition on twisted Edwards curves. -/
 @[step]
 theorem add_spec

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/CompletedPoint/AsExtended.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/CompletedPoint/AsExtended.lean
@@ -8,10 +8,9 @@ import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Math.Montgomery.Curve
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
-/-!
-# Spec theorem for `CompletedPoint::as_extended`
 
-Specification and proof for `CompletedPoint::as_extended`.
+/-! Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_extended`
 
 This function implements point conversion from completed coordinates (ℙ¹ × ℙ¹) to extended
 twisted Edwards coordinates (ℙ³) on the Curve25519 elliptic curve. Given a point
@@ -24,39 +23,19 @@ Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs"
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.u64.field
-
 namespace curve25519_dalek.backend.serial.curve_models.CompletedPoint
 
-/-
-natural language description:
-
-• Takes a CompletedPoint with coordinates (X, Y, Z, T) in completed ℙ¹ × ℙ¹ representation
-(i.e., with affine coordinates given via X/Z = x and Y/T = y) and returns an EdwardsPoint
-(X', Y', Z', T') in extended ℙ³ representation (i.e., with X'/Z' = x, Y'/Z' = y and T' = X'Y'/Z').
-Arithmetics are performed in the field 𝔽_p where p = 2^255 - 19.
-
-natural language specs:
-
-• The function always succeeds (no panic)
-• Given an input completed point (X, Y, Z, T), the output EdwardsPoint (X', Y', Z', T') satisfies:
-- X' ≡ X·T (mod p)
-- Y' ≡ Y·Z (mod p)
-- Z' ≡ Z·T (mod p)
-- T' ≡ X·Y (mod p)
--/
-
-/-- **Spec theorem for `backend.serial.curve_models.CompletedPoint.as_extended`**
-- No panic (always returns successfully)
-- Given input CompletedPoint with coordinates (X, Y, Z, T), the output EdwardsPoint (X', Y', Z', T')
-satisfies the conversion formulas modulo p:
-- X' ≡ X·T (mod p)
-- Y' ≡ Y·Z (mod p)
-- Z' ≡ Z·T (mod p)
-- T' ≡ X·Y (mod p)
-where p = 2^255 - 19
-- Output limb bounds: all coordinates have limbs < 2^52 (from mul_spec)
-These formulas implement the conversion from completed ℙ¹ × ℙ¹ coordinates to extended
-twisted Edwards ℙ³ coordinates. -/
+/-- Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_extended`
+• No panic (always returns successfully)
+• Given input CompletedPoint with coordinates (X, Y, Z, T), the output EdwardsPoint (X', Y', Z', T')
+  satisfies the conversion formulas modulo p = 2^255 - 19:
+  • X' ≡ X·T (mod p)
+  • Y' ≡ Y·Z (mod p)
+  • Z' ≡ Z·T (mod p)
+  • T' ≡ X·Y (mod p)
+• Output limb bounds: all coordinates have limbs < 2^52 (from mul_spec)
+• The output is a valid EdwardsPoint whose `toPoint` equals `q.toPoint` -/
 @[step]
 theorem as_extended_spec (q : CompletedPoint)
     (h_q_Valid : q.IsValid) :

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/CompletedPoint/AsExtended.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/CompletedPoint/AsExtended.lean
@@ -9,8 +9,10 @@ import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Math.Montgomery.Curve
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
 
-/-! Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_extended`
+/-!
+# Spec theorem
+
+Specification for `curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_extended`.
 
 This function implements point conversion from completed coordinates (ℙ¹ × ℙ¹) to extended
 twisted Edwards coordinates (ℙ³) on the Curve25519 elliptic curve. Given a point
@@ -25,8 +27,9 @@ open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.u64.field
 namespace curve25519_dalek.backend.serial.curve_models.CompletedPoint
 
-/-- Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_extended`
+/-- **Spec theorem**
+
+For `curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_extended`
 • No panic (always returns successfully)
 • Given input CompletedPoint with coordinates (X, Y, Z, T), the output EdwardsPoint (X', Y', Z', T')
   satisfies the conversion formulas modulo p = 2^255 - 19:

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/CompletedPoint/AsProjective.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/CompletedPoint/AsProjective.lean
@@ -7,10 +7,9 @@ import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
 import Curve25519Dalek.Math.Edwards.Representation
-/-!
-# Spec theorem for `CompletedPoint::as_projective`
 
-Specification and proof for `CompletedPoint::as_projective`.
+/-! Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_projective`
 
 This function implements point conversion from completed coordinates (ℙ¹ × ℙ¹) to projective
 coordinates (ℙ²) on the Curve25519 elliptic curve. Given a point P = (X:Y:Z:T) in
@@ -23,27 +22,14 @@ Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs"
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.backend.serial.curve_models.CompletedPoint
-
-/-
-natural language description:
-
-• Takes a CompletedPoint with coordinates (X, Y, Z, T) in completed ℙ¹ × ℙ¹ representation
-(i.e., with affine coordinates given via X/Z = x and Y/T = y) and returns a ProjectivePoint
-(X', Y', Z') in projective ℙ² representation (i.e., with X'/Z' = x and Y'/Z' = y).
-Arithmetics are performed in the field 𝔽_p where p = 2^255 - 19.
-
-natural language specs:
-
-• The function always succeeds (no panic)
-• Given an input completed point (X, Y, Z, T), the output ProjectivePoint (X', Y', Z') satisfies:
-- X' ≡ X·T (mod p)
-- Y' ≡ Y·Z (mod p)
-- Z' ≡ Z·T (mod p)
--/
-
 /-- **Auxiliary spec for `as_projective`** proving arithmetic correctness.
-Input bounds: all coordinates < 2^54.
-Output: arithmetic relations modulo p.
+
+• The function always succeeds (no panic) for an input completed point (X, Y, Z, T) with all
+coordinates < 2^54
+• The output ProjectivePoint (X', Y', Z') satisfies:
+  • X' ≡ X·T (mod p) where p = 2^255 - 19
+  • Y' ≡ Y·Z (mod p)
+  • Z' ≡ Z·T (mod p)
 
 The point-level `as_projective_spec` (WP form, takes `IsValid` and
 returns `IsValid ∧ toPoint = toPoint`) is the canonical chain target. -/
@@ -185,14 +171,11 @@ private lemma as_projective_isValid_and_toPoint
       rw [h_py, hY_F, hZ_F, h_qy]
       field_simp [hq_valid.Z_ne_zero, hq_valid.T_ne_zero]
 
-/--
-Verification of the `as_projective` function (WP form, canonical chain target).
-
-The theorem states that converting a valid CompletedPoint to ProjectivePoint:
-1. Always succeeds
-2. Produces a valid ProjectivePoint
-3. Preserves the represented affine point
--/
+/-- Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_projective`
+• Always succeeds for a valid CompletedPoint
+• Produces a valid ProjectivePoint
+• Preserves the represented affine point (`proj.toPoint = q.toPoint`) -/
 @[step]
 theorem as_projective_spec
     (q : CompletedPoint) (hq_valid : q.IsValid) :

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/CompletedPoint/AsProjective.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/CompletedPoint/AsProjective.lean
@@ -8,8 +8,10 @@ import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
 import Curve25519Dalek.Math.Edwards.Representation
 
-/-! Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_projective`
+/-!
+# Spec theorem
+
+Specification for `curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_projective`.
 
 This function implements point conversion from completed coordinates (ℙ¹ × ℙ¹) to projective
 coordinates (ℙ²) on the Curve25519 elliptic curve. Given a point P = (X:Y:Z:T) in
@@ -171,8 +173,9 @@ private lemma as_projective_isValid_and_toPoint
       rw [h_py, hY_F, hZ_F, h_qy]
       field_simp [hq_valid.Z_ne_zero, hq_valid.T_ne_zero]
 
-/-- Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_projective`
+/-- **Spec theorem**
+
+For `curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_projective`.
 • Always succeeds for a valid CompletedPoint
 • Produces a valid ProjectivePoint
 • Preserves the represented affine point (`proj.toPoint = q.toPoint`) -/

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/ConditionalAssign.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/ConditionalAssign.lean
@@ -8,8 +8,9 @@ import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Aux
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ConditionalAssign
-/-!
-# Spec theorem for `ProjectiveNielsPoint::conditional_assign`
+
+/-! Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_assign`
 
 This function conditionally assigns the value of another ProjectiveNielsPoint
 to self based on a Choice value. It is a constant-time operation used in
@@ -32,36 +33,17 @@ open curve25519_dalek.backend.serial.curve_models
 namespace curve25519_dalek.backend.serial.curve_models.ProjectiveNielsPoint.Insts
 namespace SubtleConditionallySelectable
 
-/-
-natural language description:
-
-• Takes a ProjectiveNielsPoint self = (Y_plus_X, Y_minus_X, Z, T2d) and another
-  ProjectiveNielsPoint other = (Y_plus_X', Y_minus_X', Z', T2d'), along with a
-  Choice value, and conditionally assigns other to self in constant time.
-
-natural language specs:
-
-• The function always succeeds (no panic)
-• Given inputs self = (Y_plus_X, Y_minus_X, Z, T2d), other = (Y_plus_X', Y_minus_X', Z', T2d'),
-  and choice, the output self' = (Y_plus_X'', Y_minus_X'', Z'', T2d'') satisfies:
-  - If choice represents 1 (true):
-    Y_plus_X'' = Y_plus_X', Y_minus_X'' = Y_minus_X', Z'' = Z', T2d'' = T2d'
-  - If choice represents 0 (false):
-    Y_plus_X'' = Y_plus_X, Y_minus_X'' = Y_minus_X, Z'' = Z, T2d'' = T2d
-  - The operation is constant-time (execution time does not depend on choice value)
--/
-
 /-- **Spec theorem for
-`backend.serial.curve_models.ConditionallySelectableProjectiveNielsPoint.conditional_assign`**
-- No panic (always returns successfully)
-- Given inputs:
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_assign`**
+• No panic (always returns successfully)
+• Given inputs:
   • a ProjectiveNielsPoint `self` with coordinates (Y_plus_X, Y_minus_X, Z, T2d),
   • a ProjectiveNielsPoint `other` with coordinates (Y_plus_X', Y_minus_X', Z', T2d'),
   • a Choice `choice`,
 the output ProjectiveNielsPoint computed by `conditional_assign self other choice` satisfies:
-- Each coordinate is conditionally selected:
-  if choice is 1, output = other; if choice is 0, output = self
-- The operation is performed in constant time for all field elements -/
+• Each coordinate is conditionally selected: if choice is 1, output = other;
+  if choice is 0, output = self
+• The operation is performed in constant time for all field elements -/
 @[step]
 theorem conditional_assign_spec
     (self other : backend.serial.curve_models.ProjectiveNielsPoint)
@@ -80,7 +62,8 @@ theorem conditional_assign_spec
   -- HACK: aeneas#963 didn't fully fix this — still needed.
   refine ⟨?_, ?_, ?_, ?_⟩ <;> intro i hi <;> split_ifs <;> simp_all
 
-/-- **Point-level wrapper for `ProjectiveNielsPoint::conditional_assign`**:
+/-- **Point-level wrapper for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_assign`**
 Given valid `self` and `other` and a `Choice`, the output is a valid `ProjectiveNielsPoint`
 whose `toPoint` equals `other.toPoint` if `choice.val = 1#u8`, otherwise `self.toPoint`.
 

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/ConditionalAssign.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/ConditionalAssign.lean
@@ -9,8 +9,11 @@ import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Aux
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ConditionalAssign
 
-/-! Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_assign`
+/-!
+# Spec theorem
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_assign`.
 
 This function conditionally assigns the value of another ProjectiveNielsPoint
 to self based on a Choice value. It is a constant-time operation used in
@@ -33,8 +36,10 @@ open curve25519_dalek.backend.serial.curve_models
 namespace curve25519_dalek.backend.serial.curve_models.ProjectiveNielsPoint.Insts
 namespace SubtleConditionallySelectable
 
-/-- **Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_assign`**
+/-- **Spec theorem**
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_assign`.
 • No panic (always returns successfully)
 • Given inputs:
   • a ProjectiveNielsPoint `self` with coordinates (Y_plus_X, Y_minus_X, Z, T2d),

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/ConditionalSelect.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/ConditionalSelect.lean
@@ -1,13 +1,14 @@
 /-
-Copyright 2025 The Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hoang Le Truong
 -/
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ConditionalSelect
-/-!
-# Spec theorem for `ProjectiveNielsPoint::conditional_select`
+
+/-! Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_select`
 
 This function conditionally selects between two ProjectiveNielsPoint values
 based on a Choice flag. It is implemented by applying
@@ -24,16 +25,16 @@ namespace curve25519_dalek.backend.serial.curve_models.ProjectiveNielsPoint.Inst
 namespace SubtleConditionallySelectable
 
 /-- **Spec theorem for
-`backend.serial.curve_models.ProjectiveNielsPoint.conditional_select`**
-- No panic (always returns successfully)
-- Given inputs:
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_select`**
+• No panic (always returns successfully)
+• Given inputs:
   • ProjectiveNielsPoint `a` with coordinates (Y_plus_X, Y_minus_X, Z, T2d),
   • ProjectiveNielsPoint `b` with coordinates (Y_plus_X', Y_minus_X', Z', T2d'),
   • a Choice `choice`,
   the output ProjectiveNielsPoint has coordinates selected component-wise:
-  - If choice = 1, each coordinate equals the corresponding one of `b`
-  - If choice = 0, each coordinate equals the corresponding one of `a`
-  - The operation is constant-time (does not branch on choice) -/
+  • If choice = 1, each coordinate equals the corresponding one of `b`
+  • If choice = 0, each coordinate equals the corresponding one of `a`
+  • The operation is constant-time (does not branch on choice) -/
 @[step]
 theorem conditional_select_spec
     (a b : backend.serial.curve_models.ProjectiveNielsPoint)

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/ConditionalSelect.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/ConditionalSelect.lean
@@ -7,8 +7,11 @@ import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ConditionalSelect
 
-/-! Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_select`
+/-!
+# Spec theorem
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_select`.
 
 This function conditionally selects between two ProjectiveNielsPoint values
 based on a Choice flag. It is implemented by applying
@@ -24,8 +27,10 @@ open curve25519_dalek.backend.serial.curve_models
 namespace curve25519_dalek.backend.serial.curve_models.ProjectiveNielsPoint.Insts
 namespace SubtleConditionallySelectable
 
-/-- **Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_select`**
+/-- **Spec theorem**
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_select`.
 • No panic (always returns successfully)
 • Given inputs:
   • ProjectiveNielsPoint `a` with coordinates (Y_plus_X, Y_minus_X, Z, T2d),

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Identity.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Identity.lean
@@ -9,8 +9,11 @@ import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ZERO
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ONE
 
-/-! Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::identity`
+/-!
+# Spec theorem
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::identity`.
 
 This function returns the identity element of the Edwards curve in ProjectiveNiels
 coordinates (Y_plus_X=1, Y_minus_X=1, Z=1, T2d=0), representing the affine point (0, 1).
@@ -25,8 +28,10 @@ namespace curve25519_dalek
 namespace backend.serial.curve_models.ProjectiveNielsPoint.Insts
 namespace Curve25519_dalekTraitsIdentity
 
-/-- **Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::identity`**
+/-- **Spec theorem**
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::identity`.
 • No panic (always returns successfully)
 • The resulting ProjectiveNielsPoint is the identity element with coordinates
   (Y_plus_X=1, Y_minus_X=1, Z=1, T2d=0)

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Identity.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Identity.lean
@@ -8,8 +8,9 @@ import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ZERO
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ONE
-/-!
-# Spec theorem for `ProjectiveNielsPoint::identity`
+
+/-! Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::identity`
 
 This function returns the identity element of the Edwards curve in ProjectiveNiels
 coordinates (Y_plus_X=1, Y_minus_X=1, Z=1, T2d=0), representing the affine point (0, 1).
@@ -20,19 +21,17 @@ Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs"
 open Aeneas Aeneas.Std Result Aeneas.Std.WP curve25519_dalek
 open backend.serial.u64.field.FieldElement51
 open backend.serial.curve_models
-
 namespace curve25519_dalek
-namespace backend.serial.curve_models.ProjectiveNielsPoint.Insts.Curve25519_dalekTraitsIdentity
+namespace backend.serial.curve_models.ProjectiveNielsPoint.Insts
+namespace Curve25519_dalekTraitsIdentity
 
 /-- **Spec theorem for
-`backend.serial.curve_models.ProjectiveNielsPoint.Insts.Curve25519_dalekTraitsIdentity.identity`**
-
-Returns the identity element of the Edwards curve in ProjectiveNiels coordinates:
-- No panic (always returns successfully)
-- The resulting ProjectiveNielsPoint is the identity element with coordinates
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::identity`**
+• No panic (always returns successfully)
+• The resulting ProjectiveNielsPoint is the identity element with coordinates
   (Y_plus_X=1, Y_minus_X=1, Z=1, T2d=0)
-- The result is a valid `ProjectiveNielsPoint`.
-- It represents the Edwards curve identity `0 = (0, 1)` (the affine neutral element). -/
+• The result is a valid `ProjectiveNielsPoint`
+• It represents the Edwards curve identity `0 = (0, 1)` (the affine neutral element) -/
 @[step]
 theorem identity_spec :
     identity ⦃ (result : ProjectiveNielsPoint) =>
@@ -55,5 +54,6 @@ theorem identity_spec :
   ext
   all_goals simp [hpx, hpy, toField, h1]
 
-end backend.serial.curve_models.ProjectiveNielsPoint.Insts.Curve25519_dalekTraitsIdentity
+end Curve25519_dalekTraitsIdentity
+end backend.serial.curve_models.ProjectiveNielsPoint.Insts
 end curve25519_dalek

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Neg.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Neg.lean
@@ -9,8 +9,10 @@ import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Math.Montgomery.Curve
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Neg
 
-/-! Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::neg`
+/-!
+# Spec theorem
+
+Specification for `curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::neg`.
 
 This function computes the negation of a ProjectiveNielsPoint. Given a point
 N = (Y+X, Y−X, Z, 2dXY), it returns −N by swapping Y_plus_X and Y_minus_X,
@@ -30,8 +32,9 @@ open curve25519_dalek.backend.serial.curve_models
 open curve25519_dalek.backend.serial.u64.field
 namespace curve25519_dalek.Shared0ProjectiveNielsPoint.Insts.CoreOpsArithNegProjectiveNielsPoint
 
-/-- Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::neg` (shared-reference)
+/-- **Spec theorem**
+
+For `curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::neg` (shared-reference)
 • No panic (always returns successfully) given `self.IsValid`
 • The output is a valid `ProjectiveNielsPoint`
 • It represents `-self.toPoint` on Ed25519
@@ -100,8 +103,10 @@ end curve25519_dalek.Shared0ProjectiveNielsPoint.Insts.CoreOpsArithNegProjective
 namespace curve25519_dalek.backend.serial.curve_models.ProjectiveNielsPoint.Insts
 namespace CoreOpsArithNegProjectiveNielsPoint
 
-/-- Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::neg`
+/-- **Spec theorem**
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::neg`.
 • No panic (always returns successfully) given `self.IsValid`
 • The output is a valid `ProjectiveNielsPoint`
 • It represents `-self.toPoint` on Ed25519

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Neg.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Neg.lean
@@ -8,8 +8,9 @@ import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Math.Edwards.Representation
 import Curve25519Dalek.Math.Montgomery.Curve
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Neg
-/-!
-# Spec theorem for `ProjectiveNielsPoint::neg`
+
+/-! Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::neg`
 
 This function computes the negation of a ProjectiveNielsPoint. Given a point
 N = (Y+X, Y−X, Z, 2dXY), it returns −N by swapping Y_plus_X and Y_minus_X,
@@ -27,23 +28,18 @@ open Edwards
 open curve25519_dalek.Shared0ProjectiveNielsPoint.Insts.CoreOpsArithNegProjectiveNielsPoint
 open curve25519_dalek.backend.serial.curve_models
 open curve25519_dalek.backend.serial.u64.field
-
 namespace curve25519_dalek.Shared0ProjectiveNielsPoint.Insts.CoreOpsArithNegProjectiveNielsPoint
 
-/-- **Spec theorem for
-`Shared0ProjectiveNielsPoint.Insts.CoreOpsArithNegProjectiveNielsPoint.neg`**:
-
-- No panic (always returns successfully) given `self.IsValid`.
-- The output is a valid `ProjectiveNielsPoint`.
-- It represents `-self.toPoint` on Ed25519.
+/-- Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::neg` (shared-reference)
+• No panic (always returns successfully) given `self.IsValid`
+• The output is a valid `ProjectiveNielsPoint`
+• It represents `-self.toPoint` on Ed25519
 
 Derived by lifting the Field51-level `FieldElement51.neg_spec` postconditions
 (`r.Y_plus_X = self.Y_minus_X`, `r.Y_minus_X = self.Y_plus_X`, `r.Z = self.Z`,
 `r.T2d ≡ -self.T2d [mod p]` with `r.T2d[i]!.val < 2^52`) through
-`ProjectiveNielsPoint.toPoint'`. `IsValid` is symmetric in `Y_plus_X`/`Y_minus_X`
-at `< 2^54`, so the swap preserves `IsValid` trivially on those fields;
-`Z` is unchanged; `T2d`'s strict `< 2^52` bound is supplied by the tightened
-`FieldElement51.neg_spec`. -/
+`ProjectiveNielsPoint.toPoint'`. -/
 @[step]
 theorem neg_spec
     (self : ProjectiveNielsPoint) (h_self : self.IsValid) :
@@ -104,8 +100,11 @@ end curve25519_dalek.Shared0ProjectiveNielsPoint.Insts.CoreOpsArithNegProjective
 namespace curve25519_dalek.backend.serial.curve_models.ProjectiveNielsPoint.Insts
 namespace CoreOpsArithNegProjectiveNielsPoint
 
-/-- **Spec theorem for the owned-value
-`ProjectiveNielsPoint.Insts.CoreOpsArithNegProjectiveNielsPoint.neg`**.
+/-- Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::neg`
+• No panic (always returns successfully) given `self.IsValid`
+• The output is a valid `ProjectiveNielsPoint`
+• It represents `-self.toPoint` on Ed25519
 
 Mirrors the shared-reference `Shared0…neg_spec`; the owned `neg` is just a
 one-step delegation to it (Rust source: `-&self`). Needed so that `let*`

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Sub.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Sub.lean
@@ -7,7 +7,10 @@ import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.CurveModels.CompletedPoint.Add
 
-/-! Spec theorem for `curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::sub`
+/-!
+# Spec theorem
+
+For `curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::sub`
 
 This function implements the mixed subtraction of a ProjectiveNielsPoint from an
 Edwards point in extended coordinates, returning the result in completed
@@ -583,7 +586,9 @@ private lemma sub_isValid_and_toPoint
       hZ1_ne hZ2_ne h_self_x h_self_y h_other_x h_other_y
       hX_factored hY_factored hZ_factored hT_factored
 
-/-- Spec theorem for `curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::sub`
+/-- **Spec theorem**
+
+For `curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::sub`
 • No panic for valid EdwardsPoints `self` and `other`
 • The output is a valid CompletedPoint `c`
 • `c.toPoint = self.toPoint - other.toPoint` -/

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Sub.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Sub.lean
@@ -6,8 +6,8 @@ Authors: Hoang Le Truong
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.CurveModels.CompletedPoint.Add
-/-!
-# Spec theorem for `ProjectiveNielsPoint::sub`
+
+/-! Spec theorem for `curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::sub`
 
 This function implements the mixed subtraction of a ProjectiveNielsPoint from an
 Edwards point in extended coordinates, returning the result in completed
@@ -31,6 +31,7 @@ The concrete formulas are:
 
 Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs"
 -/
+
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.curve_models
 open curve25519_dalek.backend.serial.u64.field
@@ -477,12 +478,11 @@ private lemma sub_toPoint_eq_proof
     field_simp [h2, hZ1_ne, hZ2_ne]
     ring_nf
 
-/- Main geometric and algebraic proof for subtraction:
+/-- Main geometric and algebraic proof for subtraction:
     given the simplified field equalities and output bounds,
     prove that the completed point is valid and represents `self - other`.
     Delegates to `sub_factored_coords`, `sub_completed_on_curve_proof`,
     and `sub_toPoint_eq_proof`. -/
-
 private lemma sub_isValid_and_toPoint
     (c : CompletedPoint)
     (self : curve25519_dalek.edwards.EdwardsPoint) (hself : self.IsValid)
@@ -583,11 +583,10 @@ private lemma sub_isValid_and_toPoint
       hZ1_ne hZ2_ne h_self_x h_self_y h_other_x h_other_y
       hX_factored hY_factored hZ_factored hT_factored
 
-/-- **Spec theorem for `sub`**
-(`CoreOpsArithSubSharedAProjectiveNielsPointCompletedPoint`)
-
-Computes `self - other` as a CompletedPoint: the result is valid
-and represents the difference of the two input points. -/
+/-- Spec theorem for `curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::sub`
+• No panic for valid EdwardsPoints `self` and `other`
+• The output is a valid CompletedPoint `c`
+• `c.toPoint = self.toPoint - other.toPoint` -/
 @[step]
 theorem sub_spec
     (self : curve25519_dalek.edwards.EdwardsPoint) (hself : self.IsValid)

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/AsExtended.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/AsExtended.lean
@@ -7,15 +7,18 @@ import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Square
-/-!
-# Spec theorem for `ProjectivePoint::as_extended`
 
-Specification and proof for `ProjectivePoint::as_extended`.
+/-! Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::ProjectivePoint::as_extended`
 
 This function implements point conversion from projective coordinates (ℙ²) to extended
 twisted Edwards coordinates (ℙ³) on the Curve25519 elliptic curve. Given a point
 P = (X:Y:Z) in projective coordinates, it computes an equivalent representation
 (X':Y':Z':T') in extended coordinates.
+
+Note: We compute the output representation (XZ, YZ, Z², XY) instead of the equivalent
+(and seemingly more straightforward) representation (X, Y, Z, XY/Z) because the former
+representation can be obtained without performing any divisions.
 
 Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs"
 -/
@@ -23,37 +26,15 @@ Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs"
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.backend.serial.curve_models.ProjectivePoint
 
-/-
-natural language description:
-
-• Takes a ProjectivePoint with coordinates (X, Y, Z) in projective ℙ² representation and
-returns an EdwardsPoint (X', Y', Z', T') in extended ℙ³ representation. Arithmetics are
-performed in the field 𝔽_p where p = 2^255 - 19.
-
-natural language specs:
-
-• The function always succeeds (no panic)
-• Given  an input projective point (X, Y, Z), the output EdwardsPoint (X', Y', Z', T') satisfies:
-- X' ≡ X·Z (mod p)
-- Y' ≡ Y·Z (mod p)
-- Z' ≡ Z² (mod p)
-- T' ≡ X·Y (mod p)
-
-Note: We compute the output representation (XZ, YZ, Z², XY) instead of the equivalent
-(and seemingly more straightforward) representation (X, Y, Z, XY/Z) because the former
-representation can be obtained without performing any divisions.
--/
-
 /-- **Spec theorem for
-`curve25519_dalek.backend.serial.curve_models.ProjectivePoint.as_extended`**
-
-Given input ProjectivePoint with coordinates (X, Y, Z), the output EdwardsPoint (X', Y', Z', T')
-satisfies the conversion formulas modulo p:
-- X' ≡ X·Z (mod p)
-- Y' ≡ Y·Z (mod p)
-- Z' ≡ Z² (mod p)
-- T' ≡ X·Y (mod p)
-where p = 2^255 - 19 -/
+`curve25519_dalek::backend::serial::curve_models::ProjectivePoint::as_extended`**
+• The function always succeeds (no panic)
+• Given input ProjectivePoint with coordinates (X, Y, Z), the output EdwardsPoint
+  (X', Y', Z', T') satisfies the conversion formulas modulo p = 2^255 - 19:
+  • X' ≡ X·Z (mod p)
+  • Y' ≡ Y·Z (mod p)
+  • Z' ≡ Z² (mod p)
+  • T' ≡ X·Y (mod p) -/
 @[step]
 theorem as_extended_spec
     (q : ProjectivePoint)

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/AsExtended.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/AsExtended.lean
@@ -8,8 +8,10 @@ import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Mul
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.Square
 
-/-! Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::ProjectivePoint::as_extended`
+/-!
+# Spec theorem
+
+Specification for `curve25519_dalek::backend::serial::curve_models::ProjectivePoint::as_extended`.
 
 This function implements point conversion from projective coordinates (ℙ²) to extended
 twisted Edwards coordinates (ℙ³) on the Curve25519 elliptic curve. Given a point
@@ -26,8 +28,9 @@ Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs"
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 namespace curve25519_dalek.backend.serial.curve_models.ProjectivePoint
 
-/-- **Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::ProjectivePoint::as_extended`**
+/-- **Spec theorem**
+
+Specification for `curve25519_dalek::backend::serial::curve_models::ProjectivePoint::as_extended`.
 • The function always succeeds (no panic)
 • Given input ProjectivePoint with coordinates (X, Y, Z), the output EdwardsPoint
   (X', Y', Z', T') satisfies the conversion formulas modulo p = 2^255 - 19:

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/Double.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/Double.lean
@@ -33,8 +33,10 @@ open curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithAddSharedAFieldEle
 open curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithSubSharedAFieldElement51FieldElement51
 namespace curve25519_dalek.backend.serial.curve_models.ProjectivePoint
 
-/-- Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::ProjectivePoint::double_spec_aux`
+/-- **Spec theorem**
+
+Specification for
+`curve25519_dalek::backend::serial::curve_models::ProjectivePoint::double_spec_aux`.
 • The function always succeeds (no panic)
 • Given input ProjectivePoint with coordinates (X, Y, Z), the output CompletedPoint
   (X', Y', Z', T') satisfies the point doubling formulas modulo p = 2^255 - 19:

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/Double.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/Double.lean
@@ -14,14 +14,7 @@ import Curve25519Dalek.Math.Edwards.Curve
 import Curve25519Dalek.Math.Edwards.Representation
 import Mathlib.Data.ZMod.Basic
 
--- Required for the #setup_aeneas_simps macro below
-set_option linter.hashCommand false
-#setup_aeneas_simps
-
-/-!
-# Spec theorem for `ProjectivePoint::double`
-
-Specification and proof for `ProjectivePoint::double`.
+/-! # Spec theorem for `curve25519_dalek::backend::serial::curve_models::ProjectivePoint::double`
 
 This function implements point doubling on the Curve25519 elliptic curve using projective
 coordinates. Given a point P = (X:Y:Z), it computes 2P (the point added to itself via
@@ -30,44 +23,27 @@ elliptic curve addition).
 Source: "curve25519-dalek/src/backend/serial/curve_models/mod.rs"
 -/
 
-open Aeneas Aeneas.Std Result Aeneas.Std.WP
+-- Required for the #setup_aeneas_simps macro below
+set_option linter.hashCommand false
+#setup_aeneas_simps
 
+open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.u64.field.FieldElement51
 open curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithAddSharedAFieldElement51FieldElement51
 open curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithSubSharedAFieldElement51FieldElement51
-
 namespace curve25519_dalek.backend.serial.curve_models.ProjectivePoint
 
-/-
-natural language description:
-
-• Takes a ProjectivePoint with coordinates (X, Y, Z) and returns a CompletedPoint that results
-from adding the input point to itself via elliptic curve point addition. Arithmetics are
-performed in the field 𝔽_p where p = 2^255 - 19.
-
-natural language specs:
-
+/-- Spec theorem for
+`curve25519_dalek::backend::serial::curve_models::ProjectivePoint::double_spec_aux`
 • The function always succeeds (no panic)
-• Given input point (X, Y, Z), the output CompletedPoint (X', Y', Z', T') satisfies:
-- X' ≡ 2XY (mod p)
-- Y' ≡ Y² + X² (mod p)
-- Z' ≡ Y² - X² (mod p)
-- T' ≡ 2Z² - Y² + X² (mod p)
--/
-
-/-- **Spec theorem for
-`curve25519_dalek.backend.serial.curve_models.ProjectivePoint.double`**
-
-Given input ProjectivePoint with coordinates (X, Y, Z), the output CompletedPoint (X', Y', Z', T')
-satisfies the point doubling formulas modulo p:
-- X' ≡ 2XY (mod p)
-- Y' ≡ Y² + X² (mod p)
-- Z' ≡ Y² - X² (mod p)
-- T' ≡ 2Z² - Y² + X² (mod p)
-where p = 2^255 - 19
-
-Input bounds: X, Y limbs < 2^53 (for X + Y < 2^54), Z limbs < 2^54.
-Output bounds: X', Z', T' limbs < 2^52, Y' limbs < 2^53.
+• Given input ProjectivePoint with coordinates (X, Y, Z), the output CompletedPoint
+  (X', Y', Z', T') satisfies the point doubling formulas modulo p = 2^255 - 19:
+  • X' ≡ 2XY (mod p)
+  • Y' ≡ Y² + X² (mod p)
+  • Z' ≡ Y² - X² (mod p)
+  • T' ≡ 2Z² - Y² + X² (mod p)
+• Input bounds: X, Y limbs < 2^53 (for X + Y < 2^54), Z limbs < 2^54
+• Output bounds: X', Z', T' limbs < 2^52, Y' limbs < 2^53
 
 TODO: Investigate if c.Y can achieve the tighter < 2^52 bound. Currently c.Y = YY + XX
 where YY, XX < 2^52, giving Y < 2^53. -/
@@ -354,9 +330,9 @@ theorem double_spec_core
             (q.toPoint' hq_on).y) := by
             rw [h_qx, h_qy]; simp only [Ed25519]; ring
 
-/-- Verification of the `double` function for `ProjectivePoint` in WP form.
-Thin wrapper over `double_spec_core`: widens bounds from `< 2^52`
-to `< 2^53` and bridges `toPoint' → toPoint`. -/
+/-- **Spec theorem for `curve25519_dalek::backend::serial::curve_models::ProjectivePoint::double`**
+• The function always succeeds (no panic) on any valid input ProjectivePoint
+• The resulting CompletedPoint is valid and represents `2 · q.toPoint` on the Edwards curve -/
 @[step]
 theorem double_spec
     (q : ProjectivePoint) (hq_valid : q.IsValid) :

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/Identity.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/Identity.lean
@@ -20,8 +20,9 @@ open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.backend.serial.u64.field.FieldElement51
 namespace curve25519_dalek.IdentityCurveModelsProjectivePoint
 
-/-- **Spec theorem for
-`curve25519_dalek::backend::serial::curve_models::ProjectivePoint::identity`**
+/-- **Spec theorem**
+
+Specification for `curve25519_dalek::backend::serial::curve_models::ProjectivePoint::identity`.
 • No panic (always returns successfully)
 • The resulting ProjectivePoint is the identity element with coordinates (X=0, Y=1, Z=1) -/
 @[step]

--- a/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/Identity.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/Identity.lean
@@ -7,8 +7,8 @@ import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ZERO
 import Curve25519Dalek.Specs.Backend.Serial.U64.Field.FieldElement51.ONE
-/-!
-# Spec theorem for `ProjectivePoint::identity`
+
+/-! # Spec theorem for `curve25519_dalek::backend::serial::curve_models::ProjectivePoint::identity`
 
 This function returns the identity element of the Edwards curve in projective coordinates
 (X=0, Y=1, Z=1), representing the affine point (0, 1).
@@ -21,11 +21,9 @@ open curve25519_dalek.backend.serial.u64.field.FieldElement51
 namespace curve25519_dalek.IdentityCurveModelsProjectivePoint
 
 /-- **Spec theorem for
-`curve25519_dalek.IdentityCurveModelsProjectivePoint.identity`**
-
-Returns the identity element of the Edwards curve in projective coordinates:
-- No panic (always returns successfully)
-- The resulting ProjectivePoint is the identity element with coordinates (X=0, Y=1, Z=1) -/
+`curve25519_dalek::backend::serial::curve_models::ProjectivePoint::identity`**
+• No panic (always returns successfully)
+• The resulting ProjectivePoint is the identity element with coordinates (X=0, Y=1, Z=1) -/
 @[step]
 theorem identity_spec :
     identity ⦃ (result : backend.serial.curve_models.ProjectivePoint) =>

--- a/functions.json
+++ b/functions.json
@@ -26,7 +26,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/Identity.lean",
    "spec_docstring":
-   "/-- **Spec theorem for\n`curve25519_dalek.IdentityCurveModelsProjectivePoint.identity`**\n\nReturns the identity element of the Edwards curve in projective coordinates:\n- No panic (always returns successfully)\n- The resulting ProjectivePoint is the identity element with coordinates (X=0, Y=1, Z=1) -/",
+   "/-- **Spec theorem**\n\nSpecification for `curve25519_dalek::backend::serial::curve_models::ProjectivePoint::identity`.\n• No panic (always returns successfully)\n• The resulting ProjectivePoint is the identity element with coordinates (X=0, Y=1, Z=1) -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{curve25519_dalek::traits::Identity for curve25519_dalek::backend::serial::curve_models::ProjectivePoint}::identity",
@@ -111,7 +111,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Neg.lean",
    "spec_docstring":
-   "/-- **Spec theorem for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::neg`**\n- No panic (always returns successfully)\n- Given input:\n  • an AffineNielsPoint `self` with coordinates (y_plus_x, y_minus_x, xy2d),\nthe output AffineNielsPoint computed by `neg self` has coordinates\n(y_plus_x', y_minus_x', xy2d') where:\n    - y_plus_x' = y_minus_x (the coordinates are swapped)\n    - y_minus_x' = y_plus_x (the coordinates are swapped)\n    - xy2d' ≡ -xy2d (mod p) (the xy2d coordinate is negated modulo p)\n\nwhere p = 2^255 - 19.\n\nThis implements the negation of a point in affine Niels coordinates. -/",
+   "/-- **Spec theorem for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::neg`**\n• The function always succeeds (no panic) for an AffineNielsPoint `self` with coordinates\n(y_plus_x, y_minus_x, xy2d)\n• The output AffineNielsPoint computed by `neg self` has coordinates (y_plus_x', y_minus_x', xy2d')\n  • y_plus_x' = y_minus_x (the coordinates are swapped)\n  • y_minus_x' = y_plus_x (the coordinates are swapped)\n  • `xy2d' ≡ -xy2d (mod p)` (the xy2d coordinate is negated modulo p = 2^255 - 19) -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{core::ops::arith::Neg<curve25519_dalek::backend::serial::curve_models::AffineNielsPoint> for &0 (curve25519_dalek::backend::serial::curve_models::AffineNielsPoint)}::neg",
@@ -154,7 +154,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Add.lean",
    "spec_docstring":
-   "/-- **Spec theorem for `CompletedPoint::add`**:\n• The function always succeeds (no panic)\n• Given inputs P = (X, Y, Z, T) and N = (Y+X, Y−X, 2dXY), the output C = (X', Y', Z', T')\n  satisfies modulo p:\n  - X' ≡ ( (Y+X)·N.y_plus_x − (Y−X)·N.y_minus_x ) (mod p)\n  - Y' ≡ ( (Y+X)·N.y_plus_x + (Y−X)·N.y_minus_x ) (mod p)\n  - Z' ≡ ( 2·Z + T·N.xy2d ) (mod p)\n  - T' ≡ ( 2·Z − T·N.xy2d ) (mod p) -/",
+   "/-- **Spec theorem**\n\nSepcification for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::add`.\n• The function always succeeds (no panic)\n• Given inputs P = (X, Y, Z, T) and N = (Y+X, Y−X, 2dXY), the output C = (X', Y', Z', T')\n  satisfies modulo p:\n  - X' ≡ ( (Y+X)·N.y_plus_x − (Y−X)·N.y_minus_x ) (mod p)\n  - Y' ≡ ( (Y+X)·N.y_plus_x + (Y−X)·N.y_minus_x ) (mod p)\n  - Z' ≡ ( 2·Z + T·N.xy2d ) (mod p)\n  - T' ≡ ( 2·Z − T·N.xy2d ) (mod p) -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{core::ops::arith::Add<&'a (curve25519_dalek::backend::serial::curve_models::AffineNielsPoint), curve25519_dalek::backend::serial::curve_models::CompletedPoint> for &1 (curve25519_dalek::edwards::EdwardsPoint)}::add",
@@ -243,7 +243,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/CompletedPoint/Add.lean",
    "spec_docstring":
-   "/-- **Spec theorem for `curve25519_dalek.backend.serial.curve_models.CompletedPoint.add`**\nThe theorem states that adding a valid EdwardsPoint with a valid ProjectiveNielsPoint:\n1. Always succeeds\n2. The output CompletedPoint is valid (bounds and algebraic properties)\n3. The output represents the sum of the input points\nThe mixed addition formulas implement elliptic curve point addition on twisted Edwards curves. -/",
+   "/-- **Spec theorem for `curve25519_dalek::backend::serial::curve_models::CompletedPoint::add`**\n• Always succeeds (no panic) when both inputs are valid\n• The output CompletedPoint is valid (bounds and algebraic properties)\n• The output represents the sum of the input points: `c.toPoint = self.toPoint + other.toPoint`\n\nThe mixed addition formulas implement elliptic curve point addition on twisted Edwards curves. -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{core::ops::arith::Add<&'a (curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint), curve25519_dalek::backend::serial::curve_models::CompletedPoint> for &1 (curve25519_dalek::edwards::EdwardsPoint)}::add",
@@ -371,7 +371,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Sub.lean",
    "spec_docstring":
-   "/-- **Spec theorem for `CompletedPoint::sub`**:\n• The function always succeeds (no panic)\n• Given inputs P = (X, Y, Z, T) and N = (Y+X, Y−X, 2dXY), the output C = (X', Y', Z', T')\n  satisfies modulo p:\n  - X' ≡ ( (Y+X)·N.y_minus_x − (Y−X)·N.y_plus_x ) (mod p)\n  - Y' ≡ ( (Y+X)·N.y_minus_x + (Y−X)·N.y_plus_x ) (mod p)\n  - Z' ≡ ( 2·Z − T·N.xy2d ) (mod p)\n  - T' ≡ ( 2·Z + T·N.xy2d ) (mod p) -/",
+   "/-- **Spec theorem for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::sub`**\n• The function always succeeds (no panic)\n• Given inputs P = (X, Y, Z, T) and N = (Y+X, Y−X, 2dXY), the output C = (X', Y', Z', T')\n  satisfies modulo p:\n  - X' ≡ ( (Y+X)·N.y_minus_x − (Y−X)·N.y_plus_x ) (mod p)\n  - Y' ≡ ( (Y+X)·N.y_minus_x + (Y−X)·N.y_plus_x ) (mod p)\n  - Z' ≡ ( 2·Z − T·N.xy2d ) (mod p)\n  - T' ≡ ( 2·Z + T·N.xy2d ) (mod p) -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{core::ops::arith::Sub<&'a (curve25519_dalek::backend::serial::curve_models::AffineNielsPoint), curve25519_dalek::backend::serial::curve_models::CompletedPoint> for &1 (curve25519_dalek::edwards::EdwardsPoint)}::sub",
@@ -460,7 +460,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Sub.lean",
    "spec_docstring":
-   "/-- **Spec theorem for `sub`**\n(`CoreOpsArithSubSharedAProjectiveNielsPointCompletedPoint`)\n\nComputes `self - other` as a CompletedPoint: the result is valid\nand represents the difference of the two input points. -/",
+   "/-- **Spec theorem**\n\nFor `curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::sub`\n• No panic for valid EdwardsPoints `self` and `other`\n• The output is a valid CompletedPoint `c`\n• `c.toPoint = self.toPoint - other.toPoint` -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{core::ops::arith::Sub<&'a (curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint), curve25519_dalek::backend::serial::curve_models::CompletedPoint> for &1 (curve25519_dalek::edwards::EdwardsPoint)}::sub",
@@ -678,7 +678,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Neg.lean",
    "spec_docstring":
-   "/-- **Spec theorem for\n`Shared0ProjectiveNielsPoint.Insts.CoreOpsArithNegProjectiveNielsPoint.neg`**:\n\n- No panic (always returns successfully) given `self.IsValid`.\n- The output is a valid `ProjectiveNielsPoint`.\n- It represents `-self.toPoint` on Ed25519.\n\nDerived by lifting the Field51-level `FieldElement51.neg_spec` postconditions\n(`r.Y_plus_X = self.Y_minus_X`, `r.Y_minus_X = self.Y_plus_X`, `r.Z = self.Z`,\n`r.T2d ≡ -self.T2d [mod p]` with `r.T2d[i]!.val < 2^52`) through\n`ProjectiveNielsPoint.toPoint'`. `IsValid` is symmetric in `Y_plus_X`/`Y_minus_X`\nat `< 2^54`, so the swap preserves `IsValid` trivially on those fields;\n`Z` is unchanged; `T2d`'s strict `< 2^52` bound is supplied by the tightened\n`FieldElement51.neg_spec`. -/",
+   "/-- **Spec theorem**\n\nFor `curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::neg` (shared-reference)\n• No panic (always returns successfully) given `self.IsValid`\n• The output is a valid `ProjectiveNielsPoint`\n• It represents `-self.toPoint` on Ed25519\n\nDerived by lifting the Field51-level `FieldElement51.neg_spec` postconditions\n(`r.Y_plus_X = self.Y_minus_X`, `r.Y_minus_X = self.Y_plus_X`, `r.Z = self.Z`,\n`r.T2d ≡ -self.T2d [mod p]` with `r.T2d[i]!.val < 2^52`) through\n`ProjectiveNielsPoint.toPoint'`. -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{core::ops::arith::Neg<curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint> for &0 (curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint)}::neg",
@@ -1861,7 +1861,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/AssertReceiverIsTotalEq.lean",
    "spec_docstring":
-   "/-- **Spec theorem for `AffineNielsPoint.Insts.CoreCmpEq.assert_receiver_is_total_eq`**:\n- No panic (always returns successfully)\n- The result is `()`\n- This is the `Eq`-trait totality assertion for `AffineNielsPoint` -/",
+   "/-- **Spec theorem**\n\nSpecification for\n`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::assert_receiver_is_total_eq`.\n• No panic (always returns successfully)\n• The result is `()`\n• This is the `Eq`-trait totality assertion for `AffineNielsPoint` -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{core::cmp::Eq for curve25519_dalek::backend::serial::curve_models::AffineNielsPoint}::assert_receiver_is_total_eq",
@@ -1903,7 +1903,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Eq.lean",
    "spec_docstring":
-   "/-- **Spec theorem for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::eq`**\n- No panic (always returns successfully)\n- Returns true iff all three coordinate comparisons return true\n- Short-circuits to false as soon as a comparison fails -/",
+   "/-- **Spec theorem for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::eq`**\n• No panic (always returns successfully)\n• Returns true iff all three coordinate comparisons return true\n• Short-circuits to false as soon as a comparison fails -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{core::cmp::PartialEq<curve25519_dalek::backend::serial::curve_models::AffineNielsPoint> for curve25519_dalek::backend::serial::curve_models::AffineNielsPoint}::eq",
@@ -2025,7 +2025,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/Identity.lean",
    "spec_docstring":
-   "/-- **Spec theorem for\n`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::identity`**\n- No panic (always returns successfully)\n- The resulting AffineNielsPoint is the identity element with coordinates:\n  y_plus_x = 1, y_minus_x = 1, xy2d = 0 -/",
+   "/-- **Spec theorem**\n\nSpecification for `curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::identity`.\n• No panic (always returns successfully)\n• The resulting AffineNielsPoint is the identity element with coordinates:\n  y_plus_x = 1, y_minus_x = 1, xy2d = 0 -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{curve25519_dalek::traits::Identity for curve25519_dalek::backend::serial::curve_models::AffineNielsPoint}::identity",
@@ -2071,7 +2071,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/ConditionalAssign.lean",
    "spec_docstring":
-   "/-- **Spec theorem for `backend::serial::curve_models::AffineNielsPoint::conditional_assign`**\n- No panic (always returns successfully)\n- Given inputs:\n  • an AffineNielsPoint `self` with coordinates (y_plus_x, y_minus_x, xy2d),\n  • an AffineNielsPoint `other` with coordinates (y_plus_x', y_minus_x', xy2d'),\n  • a Choice `choice`,\nthe output AffineNielsPoint computed by `conditional_assign self other choice` satisfies:\n- Each coordinate is conditionally selected: if choice is 1, output = other;\n  if choice is 0, output = self\n- The operation is performed in constant time for all field elements -/",
+   "/-- **Spec theorem**\n\nSpecification for\n`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_assign`.\n• No panic (always returns successfully)\n• Given inputs:\n  • an AffineNielsPoint `self` with coordinates (y_plus_x, y_minus_x, xy2d),\n  • an AffineNielsPoint `other` with coordinates (y_plus_x', y_minus_x', xy2d'),\n  • a Choice `choice`,\nthe output AffineNielsPoint computed by `conditional_assign self other choice` satisfies:\n• Each coordinate is conditionally selected: if choice is 1, output = other;\n  if choice is 0, output = self\n• The operation is performed in constant time for all field elements -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{subtle::ConditionallySelectable for curve25519_dalek::backend::serial::curve_models::AffineNielsPoint}::conditional_assign",
@@ -2094,7 +2094,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/AffineNielsPoint/ConditionalSelect.lean",
    "spec_docstring":
-   "/-- **Spec theorem for\n`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_select`**\n- No panic (always returns successfully)\n- Given inputs:\n  • AffineNielsPoint `a` with coordinates (y_plus_x, y_minus_x, xy2d),\n  • AffineNielsPoint `b` with coordinates (y_plus_x', y_minus_x', xy2d'),\n  • a Choice `choice`,\n  the output AffineNielsPoint has coordinates selected component-wise:\n  - If choice = 1, each coordinate equals the corresponding one of `b`\n  - If choice = 0, each coordinate equals the corresponding one of `a`\n  - The operation is constant-time (does not branch on choice) -/",
+   "/-- **Spec theorem**\n\nSpecification for\n`curve25519_dalek::backend::serial::curve_models::AffineNielsPoint::conditional_select`.\n• The function always succeeds (no panic) for AffineNielsPoints `a` and `b` and a Choice `choice`\n• The result is an AffineNielsPoint whose coordinates are selected component-wise:\n  - If choice = 1, each coordinate equals the corresponding one of `b`\n  - If choice = 0, each coordinate equals the corresponding one of `a`\n• The operation is constant-time (does not branch on choice) -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{subtle::ConditionallySelectable for curve25519_dalek::backend::serial::curve_models::AffineNielsPoint}::conditional_select",
@@ -2176,7 +2176,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/CompletedPoint/AsExtended.lean",
    "spec_docstring":
-   "/-- **Spec theorem for `backend.serial.curve_models.CompletedPoint.as_extended`**\n- No panic (always returns successfully)\n- Given input CompletedPoint with coordinates (X, Y, Z, T), the output EdwardsPoint (X', Y', Z', T')\nsatisfies the conversion formulas modulo p:\n- X' ≡ X·T (mod p)\n- Y' ≡ Y·Z (mod p)\n- Z' ≡ Z·T (mod p)\n- T' ≡ X·Y (mod p)\nwhere p = 2^255 - 19\n- Output limb bounds: all coordinates have limbs < 2^52 (from mul_spec)\nThese formulas implement the conversion from completed ℙ¹ × ℙ¹ coordinates to extended\ntwisted Edwards ℙ³ coordinates. -/",
+   "/-- **Spec theorem**\n\nFor `curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_extended`\n• No panic (always returns successfully)\n• Given input CompletedPoint with coordinates (X, Y, Z, T), the output EdwardsPoint (X', Y', Z', T')\n  satisfies the conversion formulas modulo p = 2^255 - 19:\n  • X' ≡ X·T (mod p)\n  • Y' ≡ Y·Z (mod p)\n  • Z' ≡ Z·T (mod p)\n  • T' ≡ X·Y (mod p)\n• Output limb bounds: all coordinates have limbs < 2^52 (from mul_spec)\n• The output is a valid EdwardsPoint whose `toPoint` equals `q.toPoint` -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{curve25519_dalek::backend::serial::curve_models::CompletedPoint}::as_extended",
@@ -2199,7 +2199,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/CompletedPoint/AsProjective.lean",
    "spec_docstring":
-   "/--\nVerification of the `as_projective` function (WP form, canonical chain target).\n\nThe theorem states that converting a valid CompletedPoint to ProjectivePoint:\n1. Always succeeds\n2. Produces a valid ProjectivePoint\n3. Preserves the represented affine point\n-/",
+   "/-- **Spec theorem**\n\nFor `curve25519_dalek::backend::serial::curve_models::CompletedPoint::as_projective`.\n• Always succeeds for a valid CompletedPoint\n• Produces a valid ProjectivePoint\n• Preserves the represented affine point (`proj.toPoint = q.toPoint`) -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{curve25519_dalek::backend::serial::curve_models::CompletedPoint}::as_projective",
@@ -2301,7 +2301,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Neg.lean",
    "spec_docstring":
-   "/-- **Spec theorem for the owned-value\n`ProjectiveNielsPoint.Insts.CoreOpsArithNegProjectiveNielsPoint.neg`**.\n\nMirrors the shared-reference `Shared0…neg_spec`; the owned `neg` is just a\none-step delegation to it (Rust source: `-&self`). Needed so that `let*`\nin downstream proofs (e.g., `LookupTable.select_spec`) matches the binding\nthat type-class resolution produces. -/",
+   "/-- **Spec theorem**\n\nSpecification for\n`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::neg`.\n• No panic (always returns successfully) given `self.IsValid`\n• The output is a valid `ProjectiveNielsPoint`\n• It represents `-self.toPoint` on Ed25519\n\nMirrors the shared-reference `Shared0…neg_spec`; the owned `neg` is just a\none-step delegation to it (Rust source: `-&self`). Needed so that `let*`\nin downstream proofs (e.g., `LookupTable.select_spec`) matches the binding\nthat type-class resolution produces. -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{core::ops::arith::Neg<curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint> for curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint}::neg",
@@ -2344,7 +2344,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/Identity.lean",
    "spec_docstring":
-   "/-- **Spec theorem for\n`backend.serial.curve_models.ProjectiveNielsPoint.Insts.Curve25519_dalekTraitsIdentity.identity`**\n\nReturns the identity element of the Edwards curve in ProjectiveNiels coordinates:\n- No panic (always returns successfully)\n- The resulting ProjectiveNielsPoint is the identity element with coordinates\n  (Y_plus_X=1, Y_minus_X=1, Z=1, T2d=0)\n- The result is a valid `ProjectiveNielsPoint`.\n- It represents the Edwards curve identity `0 = (0, 1)` (the affine neutral element). -/",
+   "/-- **Spec theorem**\n\nSpecification for\n`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::identity`.\n• No panic (always returns successfully)\n• The resulting ProjectiveNielsPoint is the identity element with coordinates\n  (Y_plus_X=1, Y_minus_X=1, Z=1, T2d=0)\n• The result is a valid `ProjectiveNielsPoint`\n• It represents the Edwards curve identity `0 = (0, 1)` (the affine neutral element) -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{curve25519_dalek::traits::Identity for curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint}::identity",
@@ -2390,7 +2390,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/ConditionalAssign.lean",
    "spec_docstring":
-   "/-- **Spec theorem for\n`backend.serial.curve_models.ConditionallySelectableProjectiveNielsPoint.conditional_assign`**\n- No panic (always returns successfully)\n- Given inputs:\n  • a ProjectiveNielsPoint `self` with coordinates (Y_plus_X, Y_minus_X, Z, T2d),\n  • a ProjectiveNielsPoint `other` with coordinates (Y_plus_X', Y_minus_X', Z', T2d'),\n  • a Choice `choice`,\nthe output ProjectiveNielsPoint computed by `conditional_assign self other choice` satisfies:\n- Each coordinate is conditionally selected:\n  if choice is 1, output = other; if choice is 0, output = self\n- The operation is performed in constant time for all field elements -/",
+   "/-- **Spec theorem**\n\nSpecification for\n`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_assign`.\n• No panic (always returns successfully)\n• Given inputs:\n  • a ProjectiveNielsPoint `self` with coordinates (Y_plus_X, Y_minus_X, Z, T2d),\n  • a ProjectiveNielsPoint `other` with coordinates (Y_plus_X', Y_minus_X', Z', T2d'),\n  • a Choice `choice`,\nthe output ProjectiveNielsPoint computed by `conditional_assign self other choice` satisfies:\n• Each coordinate is conditionally selected: if choice is 1, output = other;\n  if choice is 0, output = self\n• The operation is performed in constant time for all field elements -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{subtle::ConditionallySelectable for curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint}::conditional_assign",
@@ -2413,7 +2413,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectiveNielsPoint/ConditionalSelect.lean",
    "spec_docstring":
-   "/-- **Spec theorem for\n`backend.serial.curve_models.ProjectiveNielsPoint.conditional_select`**\n- No panic (always returns successfully)\n- Given inputs:\n  • ProjectiveNielsPoint `a` with coordinates (Y_plus_X, Y_minus_X, Z, T2d),\n  • ProjectiveNielsPoint `b` with coordinates (Y_plus_X', Y_minus_X', Z', T2d'),\n  • a Choice `choice`,\n  the output ProjectiveNielsPoint has coordinates selected component-wise:\n  - If choice = 1, each coordinate equals the corresponding one of `b`\n  - If choice = 0, each coordinate equals the corresponding one of `a`\n  - The operation is constant-time (does not branch on choice) -/",
+   "/-- **Spec theorem**\n\nSpecification for\n`curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint::conditional_select`.\n• No panic (always returns successfully)\n• Given inputs:\n  • ProjectiveNielsPoint `a` with coordinates (Y_plus_X, Y_minus_X, Z, T2d),\n  • ProjectiveNielsPoint `b` with coordinates (Y_plus_X', Y_minus_X', Z', T2d'),\n  • a Choice `choice`,\n  the output ProjectiveNielsPoint has coordinates selected component-wise:\n  • If choice = 1, each coordinate equals the corresponding one of `b`\n  • If choice = 0, each coordinate equals the corresponding one of `a`\n  • The operation is constant-time (does not branch on choice) -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{subtle::ConditionallySelectable for curve25519_dalek::backend::serial::curve_models::ProjectiveNielsPoint}::conditional_select",
@@ -2436,7 +2436,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/AsExtended.lean",
    "spec_docstring":
-   "/-- **Spec theorem for\n`curve25519_dalek.backend.serial.curve_models.ProjectivePoint.as_extended`**\n\nGiven input ProjectivePoint with coordinates (X, Y, Z), the output EdwardsPoint (X', Y', Z', T')\nsatisfies the conversion formulas modulo p:\n- X' ≡ X·Z (mod p)\n- Y' ≡ Y·Z (mod p)\n- Z' ≡ Z² (mod p)\n- T' ≡ X·Y (mod p)\nwhere p = 2^255 - 19 -/",
+   "/-- **Spec theorem**\n\nSpecification for `curve25519_dalek::backend::serial::curve_models::ProjectivePoint::as_extended`.\n• The function always succeeds (no panic)\n• Given input ProjectivePoint with coordinates (X, Y, Z), the output EdwardsPoint\n  (X', Y', Z', T') satisfies the conversion formulas modulo p = 2^255 - 19:\n  • X' ≡ X·Z (mod p)\n  • Y' ≡ Y·Z (mod p)\n  • Z' ≡ Z² (mod p)\n  • T' ≡ X·Y (mod p) -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{curve25519_dalek::backend::serial::curve_models::ProjectivePoint}::as_extended",
@@ -2460,7 +2460,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/CurveModels/ProjectivePoint/Double.lean",
    "spec_docstring":
-   "/-- Verification of the `double` function for `ProjectivePoint` in WP form.\nThin wrapper over `double_spec_core`: widens bounds from `< 2^52`\nto `< 2^53` and bridges `toPoint' → toPoint`. -/",
+   "/-- **Spec theorem for `curve25519_dalek::backend::serial::curve_models::ProjectivePoint::double`**\n• The function always succeeds (no panic) on any valid input ProjectivePoint\n• The resulting CompletedPoint is valid and represents `2 · q.toPoint` on the Edwards curve -/",
    "source": "curve25519-dalek/src/backend/serial/curve_models/mod.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::curve_models::{curve25519_dalek::backend::serial::curve_models::ProjectivePoint}::double",


### PR DESCRIPTION
I have restreamlined my files in `Specs/Backend/Serial/CurveModels` to make the style consistent with @MarkusFerdinandDablander's streamline.