### PR TITLE
Chore: remove long lines in 7 files in FieldElement51

### DIFF
--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/Add.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/Add.lean
@@ -15,13 +15,13 @@ Source: curve25519-dalek/src/backend/serial/u64/field.rs
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-open curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts.CoreOpsArithAddAssignSharedAFieldElement51
 
-namespace curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithAddSharedAFieldElement51FieldElement51
+namespace curve25519_dalek.Shared0FieldElement51.Insts
+namespace CoreOpsArithAddSharedAFieldElement51FieldElement51
 
 /-! ## Spec for `add` -/
 
-/-- **Spec for `Shared0FieldElement51.Insts.CoreOpsArithAddSharedAFieldElement51FieldElement51.add`**:
+/-- Spec for `Shared0FieldElement51.Insts.CoreOpsArithAddSharedAFieldElement51FieldElement51.add`:
 - Does not overflow when limb sums don't exceed U64.max
 - Returns a field element where each limb is the sum of corresponding input limbs
 - This is element-wise addition, not modular field addition (use reduce for that)
@@ -37,4 +37,5 @@ theorem add_spec (a b : Array U64 5#usize)
   unfold add
   step*
 
-end curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithAddSharedAFieldElement51FieldElement51
+end CoreOpsArithAddSharedAFieldElement51FieldElement51
+end curve25519_dalek.Shared0FieldElement51.Insts

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/ConditionalAssign.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/ConditionalAssign.lean
@@ -21,7 +21,8 @@ Source: curve25519-dalek/src/backend/serial/u64/field.rs (lines 250:4-256:5)
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-namespace curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts.SubtleConditionallySelectable
+namespace curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts
+namespace SubtleConditionallySelectable
 
 /-! ## Spec for `conditional_assign` -/
 
@@ -49,4 +50,5 @@ theorem conditional_assign_spec (self other : backend.serial.u64.field.FieldElem
     step*
     simp [*]
 
-end curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts.SubtleConditionallySelectable
+end SubtleConditionallySelectable
+end curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/ConditionalSelect.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/ConditionalSelect.lean
@@ -18,12 +18,14 @@ Source: curve25519-dalek/src/backend/serial/u64/field.rs (lines 228:4-240:5)
 -/
 
 open Aeneas Aeneas.Std Result
-namespace curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts.SubtleConditionallySelectable
+namespace curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts
+namespace SubtleConditionallySelectable
 
 /-! ## Spec for `conditional_select` -/
 
 /--
-**Spec for `backend.serial.u64.field.FieldElement51.Insts.SubtleConditionallySelectable.conditional_select`**:
+Spec for
+  `backend.serial.u64.field.FieldElement51.Insts.SubtleConditionallySelectable.conditional_select`:
 - No panic (always returns successfully)
 - For each limb i, the result limb equals `b[i]` when `choice = 1`,
   and equals `a[i]` when `choice = 0` (constant-time conditional select)
@@ -53,4 +55,5 @@ theorem conditional_select_spec
     simp only [Array.getElem!_Nat_eq, Array.make, List.getElem!_eq_getElem?_getD]
     rcases i with _ | _ | _ | _ | _ | n <;> simp_all; omega
 
-end curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts.SubtleConditionallySelectable
+end SubtleConditionallySelectable
+end curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/FromLimbs.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/FromLimbs.lean
@@ -23,7 +23,7 @@ namespace curve25519_dalek.backend.serial.u64.field.FieldElement51
 /-
 Natural language description:
 
-    • Constructs a field element from five u64 limbs representing a field element in 𝔽_p where p = 2^255 - 19
+    • Constructs a field element from five u64 limbs representing a field element in 𝔽_p
     • The assumed representation for a field element is in radix 2^51 form
     • Since FieldElement51 is a just type alias for `Array U64 5#usize` in Lean, this is
       merely the identity function wrapped in `Result`

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/MINUS_ONE.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/MINUS_ONE.lean
@@ -22,7 +22,7 @@ namespace curve25519_dalek.backend.serial.u64.field.FieldElement51
 /-
 natural language description:
 
-    • Represents the additive inverse of the multiplicative identity element in the field 𝔽_p where p = 2^255 - 19
+    • Represents the additive inverse of the multiplicative identity element in the field 𝔽_p
     • The field element is represented as five u64 limbs:
 
         [2251799813685228, 2251799813685247, 2251799813685247, 2251799813685247, 2251799813685247]

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/Sub.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/Sub.lean
@@ -20,9 +20,10 @@ Source: curve25519-dalek/src/backend/serial/u64/field.rs
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
-namespace curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithSubSharedAFieldElement51FieldElement51
+namespace curve25519_dalek.Shared0FieldElement51.Insts
+namespace CoreOpsArithSubSharedAFieldElement51FieldElement51
+
 open curve25519_dalek.backend.serial.u64.field.FieldElement51
-open curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithSubSharedAFieldElement51FieldElement51
 open backend.serial.u64.field
 
 /-
@@ -137,4 +138,5 @@ theorem sub_spec (a b : Array U64 5#usize)
   simp only [add_zero] at h
   exact h
 
-end curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithSubSharedAFieldElement51FieldElement51
+end CoreOpsArithSubSharedAFieldElement51FieldElement51
+end curve25519_dalek.Shared0FieldElement51.Insts

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/SubAssign.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/SubAssign.lean
@@ -21,23 +21,15 @@ Source: curve25519-dalek/src/backend/serial/u64/field.rs
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 open curve25519_dalek.Shared0FieldElement51.Insts.CoreOpsArithSubSharedAFieldElement51FieldElement51
 
-namespace curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts.CoreOpsArithSubAssignSharedAFieldElement51
+namespace curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts
+namespace CoreOpsArithSubAssignSharedAFieldElement51
 
-/-
-natural language description:
-
-    • Takes two input FieldElement51s a and b and returns another FieldElement51
-      that is a representant of the difference a - b in the field (modulo p = 2^255 - 19).
-
-    • The implementation directly delegates to `sub`.
-
-natural language specs:
-
-    • For appropriately bounded FieldElement51s a and b:
-      Field51_as_Nat(sub_assign(a, b)) ≡ Field51_as_Nat(a) - Field51_as_Nat(b) (mod p), or equivalently
-      Field51_as_Nat(sub_assign(a, b)) + Field51_as_Nat(b) ≡ Field51_as_Nat(a) (mod p)
--/
-
+/-- Spec theorem for `FieldElement51::sub_assign`.
+- Requires:
+  - The limbs of the first input to be bounded by 2^63
+  - The limbs of the second input to be bounded by 2^54
+- Limbs of the result are bounded by 2^52
+- Field51_as_Nat(sub_assign(a, b)) ≡ Field51_as_Nat(a) - Field51_as_Nat(b) (mod p) -/
 @[step]
 theorem sub_assign_spec (self _rhs : backend.serial.u64.field.FieldElement51)
     (ha : ∀ i < 5, self[i]!.val < 2 ^ 63)
@@ -48,4 +40,5 @@ theorem sub_assign_spec (self _rhs : backend.serial.u64.field.FieldElement51)
   unfold sub_assign
   step*
 
-end curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts.CoreOpsArithSubAssignSharedAFieldElement51
+end CoreOpsArithSubAssignSharedAFieldElement51
+end curve25519_dalek.backend.serial.u64.field.FieldElement51.Insts

--- a/functions.json
+++ b/functions.json
@@ -505,7 +505,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/Add.lean",
    "spec_docstring":
-   "/-- **Spec for `Shared0FieldElement51.Insts.CoreOpsArithAddSharedAFieldElement51FieldElement51.add`**:\n- Does not overflow when limb sums don't exceed U64.max\n- Returns a field element where each limb is the sum of corresponding input limbs\n- This is element-wise addition, not modular field addition (use reduce for that)\n- Input bounds: both inputs have limbs < 2^53\n- Output bounds: output has limbs < 2^54\n- Simply wraps add_assign -/",
+   "/-- Spec for `Shared0FieldElement51.Insts.CoreOpsArithAddSharedAFieldElement51FieldElement51.add`:\n- Does not overflow when limb sums don't exceed U64.max\n- Returns a field element where each limb is the sum of corresponding input limbs\n- This is element-wise addition, not modular field addition (use reduce for that)\n- Input bounds: both inputs have limbs < 2^53\n- Output bounds: output has limbs < 2^54\n- Simply wraps add_assign -/",
    "source": "curve25519-dalek/src/backend/serial/u64/field.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::u64::field::{core::ops::arith::Add<&'a (curve25519_dalek::backend::serial::u64::field::FieldElement51), curve25519_dalek::backend::serial::u64::field::FieldElement51> for &1 (curve25519_dalek::backend::serial::u64::field::FieldElement51)}::add",
@@ -3159,7 +3159,8 @@
    "theorem sub_assign_spec (self _rhs : backend.serial.u64.field.FieldElement51)\n    (ha : ∀ i < 5, self[i]!.val < 2 ^ 63)\n    (hb : ∀ i < 5, _rhs[i]!.val < 2 ^ 54) :\n    sub_assign self _rhs ⦃ (result : backend.serial.u64.field.FieldElement51) =>\n      (∀ i < 5, result[i]!.val < 2 ^ 52) ∧\n      (Field51_as_Nat result + Field51_as_Nat _rhs) % p = Field51_as_Nat self % p ⦄ := by ...",
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/SubAssign.lean",
-   "spec_docstring": null,
+   "spec_docstring":
+   "/-- Spec theorem for `FieldElement51::sub_assign`.\n- Requires:\n  - The limbs of the first input to be bounded by 2^63\n  - The limbs of the second input to be bounded by 2^54\n- Limbs of the result are bounded by 2^52\n- Field51_as_Nat(sub_assign(a, b)) ≡ Field51_as_Nat(a) - Field51_as_Nat(b) (mod p) -/",
    "source": "curve25519-dalek/src/backend/serial/u64/field.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::u64::field::{core::ops::arith::SubAssign<&'a (curve25519_dalek::backend::serial::u64::field::FieldElement51)> for curve25519_dalek::backend::serial::u64::field::FieldElement51}::sub_assign",
@@ -3227,7 +3228,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/ConditionalSelect.lean",
    "spec_docstring":
-   "/--\n**Spec for `backend.serial.u64.field.FieldElement51.Insts.SubtleConditionallySelectable.conditional_select`**:\n- No panic (always returns successfully)\n- For each limb i, the result limb equals `b[i]` when `choice = 1`,\n  and equals `a[i]` when `choice = 0` (constant-time conditional select)\n- Consequently, when `choice = Choice.one`, the whole result equals `b`;\n  when `choice = Choice.zero`, the result equals `a`.\n-/",
+   "/--\nSpec for\n  `backend.serial.u64.field.FieldElement51.Insts.SubtleConditionallySelectable.conditional_select`:\n- No panic (always returns successfully)\n- For each limb i, the result limb equals `b[i]` when `choice = 1`,\n  and equals `a[i]` when `choice = 0` (constant-time conditional select)\n- Consequently, when `choice = Choice.one`, the whole result equals `b`;\n  when `choice = Choice.zero`, the result equals `a`.\n-/",
    "source": "curve25519-dalek/src/backend/serial/u64/field.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::u64::field::{subtle::ConditionallySelectable for curve25519_dalek::backend::serial::u64::field::FieldElement51}::conditional_select",


### PR DESCRIPTION
Each of these files had long lines whcih generated warnings:

- Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/Add.lean
- Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/Sub.lean
- Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/ConditionalSelect.lean
- Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/ConditionalAssign.lean
- Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/FromLimbs.lean
- Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/MINUS_ONE.lean
- Curve25519Dalek/Specs/Backend/Serial/U64/Field/FieldElement51/SubAssign.lean



closes #840