### PR TITLE
Chore: remove long lines in several files

### DIFF
--- a/Curve25519Dalek/Math/Ristretto/Representation.lean
+++ b/Curve25519Dalek/Math/Ristretto/Representation.lean
@@ -470,7 +470,8 @@ theorem IsEven_iff_in_doubling_image_left (P : Point Ed25519) :
   have : 1 - ((y^2 + x^2) / (1 - lamVal))^2 = ((1 - lamVal)^2 - (y^2 + x^2)^2) / (1 - lamVal)^2 := by
     field_simp [h_denom_ne]
   rw [this]
-  have h_factor : (1 - lamVal)^2 - (y^2 + x^2)^2 = (1 - lamVal - y^2 - x^2) * (1 - lamVal + y^2 + x^2) := by
+  have h_factor : (1 - lamVal)^2 - (y^2 + x^2)^2 =
+      (1 - lamVal - y^2 - x^2) * (1 - lamVal + y^2 + x^2) := by
     ring
   have h_lam_eq : lamVal = y^2 - x^2 - 1 := by
     have h : y^2 - x^2 - 1 - lamVal = 0 := by linear_combination h_yx

--- a/Curve25519Dalek/Math/Ristretto/Representation.lean
+++ b/Curve25519Dalek/Math/Ristretto/Representation.lean
@@ -467,8 +467,8 @@ theorem IsEven_iff_in_doubling_image_left (P : Point Ed25519) :
   have h_denom_ne : 1 - lamVal ≠ 0 := by
     have := Ed25519.denomsNeZero Q Q
     convert this.2
-  have : 1 - ((y^2 + x^2) / (1 - lamVal))^2 = ((1 - lamVal)^2 - (y^2 + x^2)^2) / (1 - lamVal)^2 := by
-    field_simp [h_denom_ne]
+  have : 1 - ((y^2 + x^2) / (1 - lamVal))^2 =
+    ((1 - lamVal)^2 - (y^2 + x^2)^2) / (1 - lamVal)^2 := by field_simp [h_denom_ne]
   rw [this]
   have h_factor : (1 - lamVal)^2 - (y^2 + x^2)^2 =
       (1 - lamVal - y^2 - x^2) * (1 - lamVal + y^2 + x^2) := by

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Constants/Ed25519BasepointPoint.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Constants/Ed25519BasepointPoint.lean
@@ -29,19 +29,19 @@ namespace curve25519_dalek.backend.serial.u64.constants
 /-
 natural language description:
 
-    • ED25519_BASEPOINT_POINT is the standard Ed25519 basepoint,
-      which serves as the generator point for the prime order subgroup of the Ed25519 elliptic curve group.
+    • ED25519_BASEPOINT_POINT is the standard Ed25519 basepoint, which serves as the generator point
+      for the prime order subgroup of the Ed25519 elliptic curve group.
     • This constant is used as the base point for scalar multiplication operations in Ed25519.
 
 natural language specs:
 
-    • ED25519_BASEPOINT_POINT is a valid Edwards point (which amongst other things implies that it fulfills the curve equation)
+    • ED25519_BASEPOINT_POINT is a valid Edwards point and so fulfills the curve equation
     • ED25519_BASEPOINT_POINT is of prime order L
 -/
 
-/-- **Spec theorem for `curve25519_dalek::backend::serial::u64::constants::ED25519_BASEPOINT_POINT`**
+/-- Spec theorem for `curve25519_dalek::backend::serial::u64::constants::ED25519_BASEPOINT_POINT`
 
-`ED25519_BASEPOINT_POINT` is a valid Edwards point (fulfilling the curve equation) of prime order L. -/
+`ED25519_BASEPOINT_POINT` is a valid Edwards point of prime order L. -/
 @[step]
 theorem ED25519_BASEPOINT_POINT_spec :
     ED25519_BASEPOINT_POINT ⦃ (result : edwards.EdwardsPoint) =>

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Constants/SqrtAdMinusOne.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Constants/SqrtAdMinusOne.lean
@@ -21,10 +21,10 @@ namespace curve25519_dalek.backend.serial.u64.constants
 /-
 natural language description:
 
-    • constants.SQRT_AD_MINUS_ONE is a constant representing one of the square roots of (a*d - 1) (mod p)
-      where a and d are the parameters in the defining curve equation ax^2 + y^2 = 1 + dx^2y^2
-      (for Curve25519 we have a = -1).
-    • The field element constants.SQRT_AD_MINUS_ONE is represented as five u64 limbs (51-bit limbs)
+  • SQRT_AD_MINUS_ONE is a constant representing one of the square roots of (a*d - 1) (mod p)
+    where a and d are the parameters in the defining curve equation ax^2 + y^2 = 1 + dx^2y^2
+    (for Curve25519 we have a = -1).
+  • The field element constants.SQRT_AD_MINUS_ONE is represented as five u64 limbs (51-bit limbs)
 
 natural language specs:
 

--- a/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/FromMontgomery.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/U64/Scalar/Scalar52/FromMontgomery.lean
@@ -87,9 +87,9 @@ theorem from_montgomery_spec (self : Scalar52) (h_bounds : ∀ i < 5, self[i]!.v
   step*
   · intro i hi
     by_cases h_lt : i < 5
-    · rw [limbs1_post1 i h_lt (Nat.zero_le i)]; specialize h_bounds i h_lt; simp only [Array.getElem!_Nat_eq,
-      UScalarTy.U64_numBits_eq, UScalarTy.U128_numBits_eq, Nat.reduceLeDiff,
-      UScalar.cast_val_mod_pow_greater_numBits_eq, Nat.reducePow];
+    · rw [limbs1_post1 i h_lt (Nat.zero_le i)]; specialize h_bounds i h_lt;
+      simp only [Array.getElem!_Nat_eq, UScalarTy.U64_numBits_eq, UScalarTy.U128_numBits_eq,
+        Nat.reduceLeDiff, UScalar.cast_val_mod_pow_greater_numBits_eq, Nat.reducePow];
       agrind
     · rw [limbs1_post2 i hi (by omega)]
       simp only [Array.repeat, getElem!, List.getElem?_replicate, *,

--- a/functions.json
+++ b/functions.json
@@ -2572,7 +2572,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/U64/Constants/Ed25519BasepointPoint.lean",
    "spec_docstring":
-   "/-- **Spec theorem for `curve25519_dalek::backend::serial::u64::constants::ED25519_BASEPOINT_POINT`**\n\n`ED25519_BASEPOINT_POINT` is a valid Edwards point (fulfilling the curve equation) of prime order L. -/",
+   "/-- Spec theorem for `curve25519_dalek::backend::serial::u64::constants::ED25519_BASEPOINT_POINT`\n\n`ED25519_BASEPOINT_POINT` is a valid Edwards point of prime order L. -/",
    "source": "curve25519-dalek/src/backend/serial/u64/constants.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::u64::constants::ED25519_BASEPOINT_POINT",


### PR DESCRIPTION
Remove long lines in the files:

- Math/Ristretto/Representation.lean (just the long line warning, not the big math sorry)
- Specs/Backend/Serial/U64/Constants/Ed25519BasepointPoint.lean
- Specs/Backend/Serial/U64/Constants/SqrtAdMinusOne.lean
- Specs/Backend/Serial/U64/Scalar/Scalar52/FromMontgomery.lean


closes #841 