### PR TITLE
style: streamline all files in Specs/Backend/Serial/ScalarMul

### DIFF
--- a/Curve25519Dalek/Specs/Backend/Serial/ScalarMul/VariableBase/Mul.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/ScalarMul/VariableBase/Mul.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alessandro D'Angelo
 -/
@@ -16,14 +16,14 @@ import Curve25519Dalek.Specs.Scalar.Scalar.AsRadix2w
 import Curve25519Dalek.Specs.Edwards.EdwardsPoint.Identity
 import Curve25519Dalek.ExternallyVerified
 
-/-! # Spec Theorem for `variable_base::mul`
+/-! # Spec theorem for `curve25519_dalek::backend::serial::scalar_mul::variable_base::mul`
 
 Top-level constant-time variable-base scalar multiplication. Builds a lookup table
 from `point`, decomposes `scalar` into radix-16 signed digits, unrolls the first
 loop iteration (for digit 63), then runs `mul_loop` for the remaining 63 iterations,
 and finally converts back to `EdwardsPoint`.
 
-**Source**: curve25519-dalek/src/backend/serial/scalar_mul/variable_base.rs, lines 11-51
+Source: "curve25519-dalek/src/backend/serial/scalar_mul/variable_base.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
@@ -82,11 +82,11 @@ private lemma scalar_digit_63_le_8
   nlinarith [h_split, h_inner_lb, h_geom, h_V_Z, h_255_eq, h_pow_pos, h_s63_ge_9,
              mul_pos (show (0:ℤ) < 9 from by norm_num) h_pow_pos]
 
-/-- **Spec and proof concerning `variable_base.mul`**:
-- No panic (always returns successfully) given `point.IsValid` and
+/-- **Spec theorem for `curve25519_dalek::backend::serial::scalar_mul::variable_base::mul`**
+• No panic (always returns successfully) given `point.IsValid` and
   `(scalar.bytes[31]!).val ≤ 127`.
-- The result is a valid `EdwardsPoint`.
-- It represents `(U8x32_as_Nat scalar.bytes) • point.toPoint` on Ed25519.
+• The result is a valid `EdwardsPoint`.
+• It represents `(U8x32_as_Nat scalar.bytes) • point.toPoint` on Ed25519.
 -/
 @[step]
 theorem mul_spec (point : EdwardsPoint) (hpoint : point.IsValid)

--- a/Curve25519Dalek/Specs/Backend/Serial/ScalarMul/VariableBase/MulLoop.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/ScalarMul/VariableBase/MulLoop.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alessandro D'Angelo
 -/
@@ -16,15 +16,18 @@ import Curve25519Dalek.Specs.Window.LookupTable.Select
 import Curve25519Dalek.ExternallyVerified
 import Mathlib
 
-/-! # Spec Theorem for `variable_base::mul_loop`
+/-! # Spec theorem for `curve25519_dalek::backend::serial::scalar_mul::variable_base::mul_loop`
 
-Specification for the Horner radix-16 signed-digit main loop of variable-base scalar
-multiplication. Iterates `i = 63, 62, ..., 1` counting down; at each step performs 4
-doublings on `tmp1` then adds `select(lookup_table, scalar_digits[i-1])` to accumulate
-one more radix-16 digit.
+Horner radix-16 signed-digit main loop of variable-base scalar multiplication.
+Tail-recursive loop given counter `i`, a lookup table, signed digits, and a current
+accumulator `tmp1` representing `partial_i • P`:
+- If `i = 0`: returns `tmp1`.
+- Otherwise: doubles `tmp1` four times (× 16), converts to extended, selects the
+  `(i-1)`-th digit's contribution via `LookupTable.select`, adds it to `tmp1`, and
+  recurses on `i - 1`.
+Loop invariant: `tmp1.toPoint = (I8x64_partial_radix16 scalar_digits i) • P.toPoint`.
 
-**Source**: curve25519-dalek/src/backend/serial/scalar_mul/variable_base.rs, lines 36-49
-(loop 0 of `variable_base::mul`).
+Source: "curve25519-dalek/src/backend/serial/scalar_mul/variable_base.rs"
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
@@ -66,30 +69,11 @@ lemma I8x64_partial_radix16_recurrence
   rw [h_idx]
   ring
 
-/-
-natural language description:
-
-• Tail-recursive loop for variable-base scalar multiplication. Given counter `i`, table,
-  signed digits, and current accumulator `tmp1` representing `partial_i • P`, the loop:
-    - If `i = 0`: returns `tmp1`.
-    - Else: doubles `tmp1` four times (× 16), converts to extended, selects the
-      `(i-1)`-th digit's contribution via `LookupTable.select`, adds it to `tmp1`, and
-      recurses on `i - 1`.
-
-• Loop invariant:
-    tmp1.toPoint = (I8x64_partial_radix16 scalar_digits i) • P.toPoint.
-
-natural language specs:
-
-• The function always succeeds (no panic).
-• The result is a valid CompletedPoint.
-• The result represents the full radix-16 sum: `tmp.toPoint = (I8x64_as_Radix16 digits) • P`.
--/
-
-/-- **Spec and proof concerning `variable_base.mul_loop`**:
-- No panic (always returns successfully)
-- Returns a `CompletedPoint` whose Edwards point equals the full radix-16 reconstruction
-  of `scalar_digits`, scaled by `P.toPoint`.
+/-- **Spec theorem for `curve25519_dalek::backend::serial::scalar_mul::variable_base::mul_loop`**
+• No panic (always returns successfully).
+• The result is a valid `CompletedPoint`.
+• The result's Edwards point equals the full radix-16 reconstruction of `scalar_digits`,
+  scaled by `P.toPoint`.
 -/
 @[step]
 theorem mul_loop_spec

--- a/Curve25519Dalek/Specs/Backend/Serial/ScalarMul/VartimeDoubleBase/Mul.lean
+++ b/Curve25519Dalek/Specs/Backend/Serial/ScalarMul/VartimeDoubleBase/Mul.lean
@@ -6,19 +6,18 @@ Authors: Oliver Butterley, Alessandro D'Angelo, Liao Zhang
 import Curve25519Dalek.Funs
 import Curve25519Dalek.Math.Basic
 
-/-!
-# Spec theorem for `vartime_double_base::mul`
+/-! # Spec theorem for `curve25519_dalek::backend::serial::scalar_mul::vartime_double_base::mul`
 
-This function performs variable-time double-base multiplication.
+Computes the double-base scalar multiplication \(aA + bB\) in variable time, where \(B\) is
+the Ed25519 basepoint, using joint non-adjacent form (NAF) representations of the two scalars
+and precomputed NAF lookup tables for both points.
 
-Source: "curve25519-dalek/src/backend/serial/scalar_mul/vartime_double_base.rs:L1-L15"
-
-## TODO
-- Write draft specification
-- Write formal specification
-- Complete proof
+Source: "curve25519-dalek/src/backend/serial/scalar_mul/vartime_double_base.rs"
 -/
 
-open Aeneas.Std Result curve25519_dalek
+open Aeneas Aeneas.Std Result Aeneas.Std.WP
+namespace curve25519_dalek.backend.serial.scalar_mul.vartime_double_base
 
 -- Specification theorem to be written here
+
+end curve25519_dalek.backend.serial.scalar_mul.vartime_double_base

--- a/functions.json
+++ b/functions.json
@@ -2486,7 +2486,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/ScalarMul/VariableBase/Mul.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `variable_base.mul`**:\n- No panic (always returns successfully) given `point.IsValid` and\n  `(scalar.bytes[31]!).val ≤ 127`.\n- The result is a valid `EdwardsPoint`.\n- It represents `(U8x32_as_Nat scalar.bytes) • point.toPoint` on Ed25519.\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::backend::serial::scalar_mul::variable_base::mul`**\n• No panic (always returns successfully) given `point.IsValid` and\n  `(scalar.bytes[31]!).val ≤ 127`.\n• The result is a valid `EdwardsPoint`.\n• It represents `(U8x32_as_Nat scalar.bytes) • point.toPoint` on Ed25519.\n-/",
    "source": "curve25519-dalek/src/backend/serial/scalar_mul/variable_base.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::scalar_mul::variable_base::mul",
@@ -2518,7 +2518,7 @@
    "spec_file":
    "Curve25519Dalek/Specs/Backend/Serial/ScalarMul/VariableBase/MulLoop.lean",
    "spec_docstring":
-   "/-- **Spec and proof concerning `variable_base.mul_loop`**:\n- No panic (always returns successfully)\n- Returns a `CompletedPoint` whose Edwards point equals the full radix-16 reconstruction\n  of `scalar_digits`, scaled by `P.toPoint`.\n-/",
+   "/-- **Spec theorem for `curve25519_dalek::backend::serial::scalar_mul::variable_base::mul_loop`**\n• No panic (always returns successfully).\n• The result is a valid `CompletedPoint`.\n• The result's Edwards point equals the full radix-16 reconstruction of `scalar_digits`,\n  scaled by `P.toPoint`.\n-/",
    "source": "curve25519-dalek/src/backend/serial/scalar_mul/variable_base.rs",
    "rust_name":
    "curve25519_dalek::backend::serial::scalar_mul::variable_base::mul",


### PR DESCRIPTION
Restreamline all files in `Specs/Backend/Serial/ScalarMul` to make them consistent with @MarkusFerdinandDablander's work