### PR TITLE
ci: move warning-diff comment to workflow_run for fork PR support

### DIFF
--- a/.github/workflows/warning-diff-comment.yml
+++ b/.github/workflows/warning-diff-comment.yml
@@ -1,0 +1,40 @@
+name: Warning Diff Comment
+# Posts the warning-diff PR comment after the Warning Diff workflow
+# completes. Because workflow_run always executes in the context of the
+# *base* repository, the GITHUB_TOKEN has write access even for fork PRs.
+
+on:
+  workflow_run:
+    workflows: ["Warning Diff"]
+    types: [completed]
+
+jobs:
+  comment:
+    name: Post Warning Diff Comment
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Download warning diff artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: warning-diff-comment
+          path: warning-diff-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat warning-diff-comment/pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Post PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.number }}
+          path: warning-diff-comment/.warning-diff-comment.md

--- a/.github/workflows/warning-diff.yml
+++ b/.github/workflows/warning-diff.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   warning-diff:
@@ -36,8 +34,17 @@ jobs:
         id: diff
         run: node scripts/warning-diff.js ${{ github.event.pull_request.base.sha }} ${{ github.sha }}
 
-      - name: Post PR comment
+      - name: Save PR number
         if: steps.diff.outputs.has_diff == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload warning diff artifact
+        if: steps.diff.outputs.has_diff == 'true'
+        uses: actions/upload-artifact@v4
         with:
-          path: .warning-diff-comment.md
+          name: warning-diff-comment
+          path: |
+            .warning-diff-comment.md
+            pr-number.txt
+          if-no-files-found: ignore
+          retention-days: 1


### PR DESCRIPTION
Fork PRs get a read-only `GITHUB_TOKEN`, so `marocchino/sticky-pull-request-comment` fails with "Resource not accessible by integration" when triggered from a `pull_request` workflow (see [PR #853 CI failure](https://github.com/Beneficial-AI-Foundation/curve25519-dalek-lean-verify/actions/runs/26933932776/job/79469464221))

To address this, this PR splits the comment-posting into a separate `workflow_run`-triggered workflow (`warning-diff-comment.yml`) which always runs in the base repo context with write permissions.
(The same pattern was used in [SPQR-verify](https://github.com/Beneficial-AI-Foundation/SparsePostQuantumRatchet-verify/commit/c59a34a03ca423e8d0dd83fc1892c686b82f18d1))

Made with [Cursor](https://cursor.com)